### PR TITLE
feat(JAR-430): rebuild pricing page — Trip Pass + Explore per approved handoff

### DIFF
--- a/src/app/pages/PricingPage.tsx
+++ b/src/app/pages/PricingPage.tsx
@@ -8,6 +8,13 @@ import { Link } from 'react-router-dom';
 // separate tiers. Quarterly is deliberately not shown (brand-owner call,
 // JAR-430). No scarcity language, no discount framing, no future tiers.
 // Bullet copy is the handoff's card language verbatim.
+//
+// The highlight travels (brand-owner direction): exactly one card wears the
+// Ateneo treatment at a time. Explore holds it by default; while the visitor
+// hovers or keyboard-focuses Trip Pass, the highlight shifts there and
+// Explore goes quiet; it shifts back the moment they leave. One boolean
+// drives both cards, so exactly one solid amber pill is visible at any
+// moment. Touch devices keep the default (Explore highlighted).
 
 const TRIP_PASS_POINTS = [
   'Full access to plan and execute one trip',
@@ -38,14 +45,22 @@ const CADENCES: Cadence[] = [
   { key: 'monthly', label: 'Monthly', amount: '$11.95', per: 'month' },
 ];
 
+// The two visual states a card can be in. Both keep a 1px border so nothing
+// shifts when the highlight moves; the hero border matches its own ground.
+const heroCard = 'bg-sky-600 border-sky-600';
+const quietCard = 'bg-white border-gray-200';
+
 export function PricingPage() {
   const [cadenceKey, setCadenceKey] = useState<CadenceKey>('annual');
   const cadence = CADENCES.find((c) => c.key === cadenceKey) ?? CADENCES[0];
 
+  // True while the visitor is over (or keyboard-focused inside) Trip Pass.
+  const [tripActive, setTripActive] = useState(false);
+  const exploreHot = !tripActive;
+
   return (
     <div className="pt-20">
-      {/* Header - flat Ateneo band. The h1 is the approved positioning line;
-          the subhead is the handoff's approved pricing message. */}
+      {/* Header - flat Ateneo band. */}
       <section className="bg-sky-600">
         <div className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 py-20 md:py-24">
           <p className="text-[11px] font-semibold tracking-[0.14em] uppercase text-amber-400 mb-6">
@@ -61,53 +76,106 @@ export function PricingPage() {
         </div>
       </section>
 
-      {/* The two offers - Moonlight ground, Explore is the hero. */}
+      {/* The two offers - Moonlight ground, one traveling highlight. */}
       <section className="bg-gray-50">
         <div className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 py-16 md:py-20">
           <div className="grid md:grid-cols-5 gap-6 items-stretch">
-            {/* Trip Pass - the entry offer. Explore is pre-highlighted as the
-                hero; when a visitor hovers (or keyboard-focuses into) this
-                tile, it takes on the full Explore treatment and its Sign up
-                becomes the same amber pill. Touch devices keep the quiet
-                default. */}
-            <div className="group md:col-span-2 bg-white border border-gray-200 rounded-[14px] p-8 flex flex-col transition-colors duration-200 hover:bg-sky-600 hover:border-sky-600 focus-within:bg-sky-600 focus-within:border-sky-600">
-              <h2 className="text-[11px] font-semibold tracking-[0.14em] uppercase text-amber-700 mb-4 transition-colors group-hover:text-amber-400 group-focus-within:text-amber-400">
+            {/* Trip Pass - the entry offer. */}
+            <div
+              onMouseEnter={() => setTripActive(true)}
+              onMouseLeave={() => setTripActive(false)}
+              onFocusCapture={() => setTripActive(true)}
+              onBlurCapture={() => setTripActive(false)}
+              className={`md:col-span-2 border rounded-[14px] p-8 flex flex-col transition-colors duration-200 ${
+                tripActive ? heroCard : quietCard
+              }`}
+            >
+              <h2
+                className={`text-[11px] font-semibold tracking-[0.14em] uppercase mb-4 transition-colors ${
+                  tripActive ? 'text-amber-400' : 'text-amber-700'
+                }`}
+              >
                 Trip Pass
               </h2>
               <div className="mb-2 [font-variant-numeric:tabular-nums]">
-                <span className="text-4xl font-bold text-gray-900 transition-colors group-hover:text-gray-50 group-focus-within:text-gray-50">$24.95</span>
-                <span className="text-gray-500 ml-2 transition-colors group-hover:text-sky-200 group-focus-within:text-sky-200">per trip</span>
+                <span
+                  className={`text-4xl font-bold transition-colors ${
+                    tripActive ? 'text-gray-50' : 'text-gray-900'
+                  }`}
+                >
+                  $24.95
+                </span>
+                <span
+                  className={`ml-2 transition-colors ${
+                    tripActive ? 'text-sky-200' : 'text-gray-500'
+                  }`}
+                >
+                  per trip
+                </span>
               </div>
-              <p className="text-lg font-semibold text-gray-900 mb-6 transition-colors group-hover:text-gray-50 group-focus-within:text-gray-50">
+              <p
+                className={`text-lg font-semibold mb-6 transition-colors ${
+                  tripActive ? 'text-gray-50' : 'text-gray-900'
+                }`}
+              >
                 One trip. Full access. No subscription required.
               </p>
               <ul className="space-y-3 mb-8">
                 {TRIP_PASS_POINTS.map((point) => (
                   <li key={point} className="flex items-start gap-3">
                     <Check
-                      className="w-4 h-4 text-sky-600 flex-shrink-0 mt-1 transition-colors group-hover:text-sky-300 group-focus-within:text-sky-300"
+                      className={`w-4 h-4 flex-shrink-0 mt-1 transition-colors ${
+                        tripActive ? 'text-sky-300' : 'text-sky-600'
+                      }`}
                       strokeWidth={2}
                       aria-hidden="true"
                     />
-                    <span className="text-gray-600 transition-colors group-hover:text-sky-100 group-focus-within:text-sky-100">{point}</span>
+                    <span
+                      className={`transition-colors ${
+                        tripActive ? 'text-sky-100' : 'text-gray-600'
+                      }`}
+                    >
+                      {point}
+                    </span>
                   </li>
                 ))}
               </ul>
               {/* Routes to the interest form until the app/payment flow is live. */}
               <Link
                 to="/contact"
-                className="mt-auto self-start px-8 py-3.5 rounded-full font-semibold border border-gray-300 text-gray-900 transition-colors group-hover:bg-amber-400 group-hover:border-amber-400 group-hover:text-gray-900 group-focus-within:bg-amber-400 group-focus-within:border-amber-400 group-focus-within:text-gray-900 hover:bg-amber-300 hover:border-amber-300"
+                className={`mt-auto self-start px-8 py-3.5 rounded-full font-semibold border transition-colors text-gray-900 ${
+                  tripActive
+                    ? 'bg-amber-400 border-amber-400 hover:bg-amber-300 hover:border-amber-300'
+                    : 'bg-transparent border-gray-300'
+                }`}
               >
                 Sign up
               </Link>
             </div>
 
-            {/* Explore - the hero offer, on the Ateneo panel. */}
-            <div className="md:col-span-3 bg-sky-600 rounded-[14px] p-8 flex flex-col">
-              <h2 className="text-[11px] font-semibold tracking-[0.14em] uppercase text-amber-400 mb-4">
+            {/* Explore - the hero offer; holds the highlight unless Trip Pass
+                has the visitor's attention. Entering Explore reclaims the
+                highlight directly (not only via Trip Pass's mouseleave), so
+                the shift back is immediate and robust. */}
+            <div
+              onMouseEnter={() => setTripActive(false)}
+              onFocusCapture={() => setTripActive(false)}
+              className={`md:col-span-3 border rounded-[14px] p-8 flex flex-col transition-colors duration-200 ${
+                exploreHot ? heroCard : quietCard
+              }`}
+            >
+              <h2
+                className={`text-[11px] font-semibold tracking-[0.14em] uppercase mb-4 transition-colors ${
+                  exploreHot ? 'text-amber-400' : 'text-amber-700'
+                }`}
+              >
                 Explore
               </h2>
-              <p className="text-lg font-semibold text-gray-50 mb-6">
+              <p
+                className={`text-lg font-semibold mb-6 transition-colors ${
+                  exploreHot ? 'text-gray-50' : 'text-gray-900'
+                }`}
+              >
                 The full JarvisTravel subscription for travelers who want
                 ongoing access.
               </p>
@@ -118,48 +186,94 @@ export function PricingPage() {
                 aria-label="Explore billing options"
                 className="grid gap-2 mb-6"
               >
-                {CADENCES.map((option) => (
-                  <button
-                    key={option.key}
-                    type="button"
-                    aria-pressed={cadenceKey === option.key}
-                    onClick={() => setCadenceKey(option.key)}
-                    className={`flex items-center justify-between rounded-xl border px-4 py-3 text-left transition-colors ${
-                      cadenceKey === option.key
-                        ? 'border-sky-300 bg-sky-500/30'
-                        : 'border-sky-400 hover:border-sky-300'
-                    }`}
-                  >
-                    <span className="flex items-center gap-3">
-                      <span className="font-medium text-gray-50">{option.label}</span>
-                      {option.best && (
-                        <span className="text-[11px] font-semibold tracking-wide uppercase text-amber-400 bg-amber-400/[0.12] border border-amber-400/30 px-2 py-0.5 rounded-full">
-                          Best value
+                {CADENCES.map((option) => {
+                  const selected = cadenceKey === option.key;
+                  const rowClass = exploreHot
+                    ? selected
+                      ? 'border-sky-300 bg-sky-500/30'
+                      : 'border-sky-400 hover:border-sky-300'
+                    : selected
+                      ? 'border-sky-600 bg-sky-600/10'
+                      : 'border-gray-300 hover:border-sky-600';
+                  return (
+                    <button
+                      key={option.key}
+                      type="button"
+                      aria-pressed={selected}
+                      onClick={() => setCadenceKey(option.key)}
+                      className={`flex items-center justify-between rounded-xl border px-4 py-3 text-left transition-colors ${rowClass}`}
+                    >
+                      <span className="flex items-center gap-3">
+                        <span
+                          className={`font-medium transition-colors ${
+                            exploreHot ? 'text-gray-50' : 'text-gray-900'
+                          }`}
+                        >
+                          {option.label}
                         </span>
-                      )}
-                    </span>
-                    <span className="text-sky-100 [font-variant-numeric:tabular-nums]">
-                      {option.amount}
-                      <span className="text-sky-200">/{option.per}</span>
-                    </span>
-                  </button>
-                ))}
+                        {option.best && (
+                          <span
+                            className={`text-[11px] font-semibold tracking-wide uppercase bg-amber-400/[0.12] border border-amber-400/30 px-2 py-0.5 rounded-full transition-colors ${
+                              exploreHot ? 'text-amber-400' : 'text-amber-700'
+                            }`}
+                          >
+                            Best value
+                          </span>
+                        )}
+                      </span>
+                      <span
+                        className={`[font-variant-numeric:tabular-nums] transition-colors ${
+                          exploreHot ? 'text-sky-100' : 'text-gray-600'
+                        }`}
+                      >
+                        {option.amount}
+                        <span
+                          className={`transition-colors ${
+                            exploreHot ? 'text-sky-200' : 'text-gray-500'
+                          }`}
+                        >
+                          /{option.per}
+                        </span>
+                      </span>
+                    </button>
+                  );
+                })}
               </div>
 
               <div className="mb-6 [font-variant-numeric:tabular-nums]">
-                <span className="text-4xl font-bold text-gray-50">{cadence.amount}</span>
-                <span className="text-sky-200 ml-2">per {cadence.per}</span>
+                <span
+                  className={`text-4xl font-bold transition-colors ${
+                    exploreHot ? 'text-gray-50' : 'text-gray-900'
+                  }`}
+                >
+                  {cadence.amount}
+                </span>
+                <span
+                  className={`ml-2 transition-colors ${
+                    exploreHot ? 'text-sky-200' : 'text-gray-500'
+                  }`}
+                >
+                  per {cadence.per}
+                </span>
               </div>
 
               <ul className="space-y-3 mb-8">
                 {EXPLORE_POINTS.map((point) => (
                   <li key={point} className="flex items-start gap-3">
                     <Check
-                      className="w-4 h-4 text-sky-300 flex-shrink-0 mt-1"
+                      className={`w-4 h-4 flex-shrink-0 mt-1 transition-colors ${
+                        exploreHot ? 'text-sky-300' : 'text-sky-600'
+                      }`}
                       strokeWidth={2}
                       aria-hidden="true"
                     />
-                    <span className="text-sky-100">{point}</span>
+                    <span
+                      className={`transition-colors ${
+                        exploreHot ? 'text-sky-100' : 'text-gray-600'
+                      }`}
+                    >
+                      {point}
+                    </span>
                   </li>
                 ))}
               </ul>
@@ -167,16 +281,20 @@ export function PricingPage() {
               {/* Routes to the interest form until the app/payment flow is live. */}
               <Link
                 to="/contact"
-                className="mt-auto w-full py-3.5 bg-amber-400 text-gray-900 rounded-full font-semibold text-center hover:bg-amber-300 transition-colors"
+                className={`mt-auto w-full py-3.5 rounded-full font-semibold text-center border transition-colors text-gray-900 ${
+                  exploreHot
+                    ? 'bg-amber-400 border-amber-400 hover:bg-amber-300 hover:border-amber-300'
+                    : 'bg-transparent border-gray-300'
+                }`}
               >
                 Sign up
               </Link>
             </div>
           </div>
 
-          {/* The upgrade path, framed simply - and the honesty line. */}
+          {/* The upgrade path, framed simply. */}
           <div className="max-w-2xl mx-auto text-center mt-14">
-            <p className="text-gray-900 font-medium mb-3">
+            <p className="text-gray-900 font-medium">
               Start with Trip Pass, then move to Explore when you're ready to
               travel more.
             </p>

--- a/src/app/pages/PricingPage.tsx
+++ b/src/app/pages/PricingPage.tsx
@@ -1,126 +1,186 @@
 import { useState } from 'react';
-import { Check } from 'lucide-react';
-import { useNavigate } from 'react-router-dom';
+import { ArrowRight, Check } from 'lucide-react';
+import { Link } from 'react-router-dom';
 
-interface Plan {
-  name: string;
-  price: { monthly: number; annual: number };
-  features: string[];
-  color: string;
-  popular: boolean;
+// Approved offer structure (pricing handoff, 2026-07): exactly two offers.
+// Trip Pass is a real single-trip product, not a trial. Explore is the hero
+// offer; Annual and Monthly are billing cadences of ONE subscription, never
+// separate tiers. Quarterly is deliberately not shown (brand-owner call,
+// JAR-430). No scarcity language, no discount framing, no future tiers.
+// Bullet copy is the handoff's card language verbatim.
+
+const TRIP_PASS_POINTS = [
+  'Full access to plan and execute one trip',
+  'Your trip journal stays with you after the trip',
+  'Good for travelers who have one trip in mind right now',
+];
+
+const EXPLORE_POINTS = [
+  'Full subscription access',
+  'Best choice for travelers planning more than one trip',
+  'Explore Annual is the best value at $99 per year',
+];
+
+type CadenceKey = 'annual' | 'monthly';
+
+interface Cadence {
+  key: CadenceKey;
+  label: string;
+  amount: string;
+  per: string;
+  best?: boolean;
 }
 
-const PLANS: Plan[] = [
-  {
-    name: 'Explorer',
-    price: { monthly: 9.99, annual: 99 },
-    features: ['3 trips per year', 'Basic AI planning', 'Budget tracking', 'Email support'],
-    color: 'slate',
-    popular: false,
-  },
-  {
-    name: 'Adventurer',
-    price: { monthly: 19.99, annual: 199 },
-    features: [
-      'Unlimited trips',
-      'Advanced AI + Fatigue Index™',
-      'Receipt scanning',
-      'Group features',
-      'Priority support',
-    ],
-    color: 'sky',
-    popular: true,
-  },
-  {
-    name: 'Globetrotter',
-    price: { monthly: 39.99, annual: 399 },
-    features: [
-      'Everything in Adventurer',
-      'Family sharing (5 users)',
-      'Concierge phone support',
-      'Travel insurance discounts',
-      'Early feature access',
-    ],
-    color: 'indigo',
-    popular: false,
-  },
+// Single source of truth for Explore pricing — rows and the summary price
+// both render from here.
+const CADENCES: Cadence[] = [
+  { key: 'annual', label: 'Annual', amount: '$99', per: 'year', best: true },
+  { key: 'monthly', label: 'Monthly', amount: '$11.95', per: 'month' },
 ];
 
 export function PricingPage() {
-  const navigate = useNavigate();
-  const [annual, setAnnual] = useState(true);
+  const [cadenceKey, setCadenceKey] = useState<CadenceKey>('annual');
+  const cadence = CADENCES.find((c) => c.key === cadenceKey) ?? CADENCES[0];
 
   return (
     <div className="pt-20">
-      <section className="py-24 bg-gradient-to-br from-slate-50 to-indigo-50">
-        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-          <div className="text-center mb-12">
-            <h1 className="text-5xl font-bold text-gray-900 mb-6">Simple, Transparent Pricing</h1>
-            <p className="text-xl text-gray-600 mb-8">Start free. Upgrade when you're ready.</p>
+      {/* Header — flat Ateneo band. The h1 is the approved positioning line;
+          the subhead is the handoff's approved pricing message. */}
+      <section className="bg-sky-600">
+        <div className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 py-20 md:py-24">
+          <p className="text-[11px] font-semibold tracking-[0.14em] uppercase text-amber-400 mb-6">
+            Pricing
+          </p>
+          <h1 className="text-4xl md:text-5xl font-bold text-gray-50 leading-tight [text-wrap:balance] max-w-3xl mb-6">
+            Plan one trip your way, or subscribe for your next one too.
+          </h1>
+          <p className="text-lg text-sky-100 max-w-2xl leading-relaxed">
+            Pay for a single trip with Trip Pass, or subscribe with Explore for
+            ongoing access and the best value.
+          </p>
+        </div>
+      </section>
 
-            <div className="inline-flex items-center p-1 bg-gray-100 rounded-full">
-              <button
-                type="button"
-                onClick={() => setAnnual(false)}
-                className={`px-6 py-2 rounded-full font-medium transition-all ${
-                  !annual ? 'bg-white shadow text-gray-900' : 'text-gray-500'
-                }`}
+      {/* The two offers — Moonlight ground, Explore is the hero. */}
+      <section className="bg-gray-50">
+        <div className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 py-16 md:py-20">
+          <div className="grid md:grid-cols-5 gap-6 items-stretch">
+            {/* Trip Pass — the entry offer. Simpler panel, secondary action. */}
+            <div className="md:col-span-2 bg-white border border-gray-200 rounded-[14px] p-8 flex flex-col">
+              <h2 className="text-[11px] font-semibold tracking-[0.14em] uppercase text-amber-700 mb-4">
+                Trip Pass
+              </h2>
+              <div className="mb-2 [font-variant-numeric:tabular-nums]">
+                <span className="text-4xl font-bold text-gray-900">$24.95</span>
+                <span className="text-gray-500 ml-2">per trip</span>
+              </div>
+              <p className="text-lg font-semibold text-gray-900 mb-6">
+                One trip. Full access. No subscription required.
+              </p>
+              <ul className="space-y-3 mb-8">
+                {TRIP_PASS_POINTS.map((point) => (
+                  <li key={point} className="flex items-start gap-3">
+                    <Check
+                      className="w-4 h-4 text-sky-600 flex-shrink-0 mt-1"
+                      strokeWidth={2}
+                      aria-hidden="true"
+                    />
+                    <span className="text-gray-600">{point}</span>
+                  </li>
+                ))}
+              </ul>
+              {/* Routes to the interest form until the app/payment flow is live. */}
+              <Link
+                to="/contact"
+                className="mt-auto self-start inline-flex items-center gap-1.5 py-2 font-medium text-sky-600 underline underline-offset-4 decoration-1 hover:text-sky-700 transition-colors"
               >
-                Monthly
-              </button>
-              <button
-                type="button"
-                onClick={() => setAnnual(true)}
-                className={`px-6 py-2 rounded-full font-medium transition-all ${
-                  annual ? 'bg-white shadow text-gray-900' : 'text-gray-500'
-                }`}
+                Sign up
+                <ArrowRight className="w-4 h-4" strokeWidth={2} aria-hidden="true" />
+              </Link>
+            </div>
+
+            {/* Explore — the hero offer, on the Ateneo panel. */}
+            <div className="md:col-span-3 bg-sky-600 rounded-[14px] p-8 flex flex-col">
+              <h2 className="text-[11px] font-semibold tracking-[0.14em] uppercase text-amber-400 mb-4">
+                Explore
+              </h2>
+              <p className="text-lg font-semibold text-gray-50 mb-6">
+                The full JarvisTravel subscription for travelers who want
+                ongoing access.
+              </p>
+
+              {/* Billing cadence — two ways to pay for the same subscription. */}
+              <div
+                role="group"
+                aria-label="Explore billing options"
+                className="grid gap-2 mb-6"
               >
-                Annual <span className="text-emerald-600 text-sm ml-1">Save 17%</span>
-              </button>
+                {CADENCES.map((option) => (
+                  <button
+                    key={option.key}
+                    type="button"
+                    aria-pressed={cadenceKey === option.key}
+                    onClick={() => setCadenceKey(option.key)}
+                    className={`flex items-center justify-between rounded-xl border px-4 py-3 text-left transition-colors ${
+                      cadenceKey === option.key
+                        ? 'border-sky-300 bg-sky-500/30'
+                        : 'border-sky-400 hover:border-sky-300'
+                    }`}
+                  >
+                    <span className="flex items-center gap-3">
+                      <span className="font-medium text-gray-50">{option.label}</span>
+                      {option.best && (
+                        <span className="text-[11px] font-semibold tracking-wide uppercase text-amber-400 bg-amber-400/[0.12] border border-amber-400/30 px-2 py-0.5 rounded-full">
+                          Best value
+                        </span>
+                      )}
+                    </span>
+                    <span className="text-sky-100 [font-variant-numeric:tabular-nums]">
+                      {option.amount}
+                      <span className="text-sky-200">/{option.per}</span>
+                    </span>
+                  </button>
+                ))}
+              </div>
+
+              <div className="mb-6 [font-variant-numeric:tabular-nums]">
+                <span className="text-4xl font-bold text-gray-50">{cadence.amount}</span>
+                <span className="text-sky-200 ml-2">per {cadence.per}</span>
+              </div>
+
+              <ul className="space-y-3 mb-8">
+                {EXPLORE_POINTS.map((point) => (
+                  <li key={point} className="flex items-start gap-3">
+                    <Check
+                      className="w-4 h-4 text-sky-300 flex-shrink-0 mt-1"
+                      strokeWidth={2}
+                      aria-hidden="true"
+                    />
+                    <span className="text-sky-100">{point}</span>
+                  </li>
+                ))}
+              </ul>
+
+              {/* Routes to the interest form until the app/payment flow is live. */}
+              <Link
+                to="/contact"
+                className="mt-auto w-full py-3.5 bg-amber-400 text-gray-900 rounded-full font-semibold text-center hover:bg-amber-300 transition-colors"
+              >
+                Sign up
+              </Link>
             </div>
           </div>
 
-          <div className="grid md:grid-cols-3 gap-8 max-w-5xl mx-auto">
-            {PLANS.map((plan, i) => (
-              <div
-                key={i}
-                className={`relative bg-white rounded-3xl p-8 ${
-                  plan.popular ? 'ring-2 ring-sky-500 shadow-xl' : 'shadow-sm border border-gray-100'
-                }`}
-              >
-                {plan.popular && (
-                  <div className="absolute -top-4 left-1/2 -translate-x-1/2 px-4 py-1 bg-sky-500 text-white text-sm font-medium rounded-full">
-                    Most Popular
-                  </div>
-                )}
-                <h3 className="text-2xl font-bold text-gray-900 mb-2">{plan.name}</h3>
-                <div className="mb-6">
-                  <span className="text-4xl font-bold text-gray-900">
-                    ${annual ? plan.price.annual : plan.price.monthly}
-                  </span>
-                  <span className="text-gray-500">/{annual ? 'year' : 'month'}</span>
-                </div>
-                <ul className="space-y-3 mb-8">
-                  {plan.features.map((feature, j) => (
-                    <li key={j} className="flex items-start">
-                      <Check className={`w-5 h-5 text-${plan.color}-500 mr-3 flex-shrink-0 mt-0.5`} />
-                      <span className="text-gray-600">{feature}</span>
-                    </li>
-                  ))}
-                </ul>
-                <button
-                  type="button"
-                  onClick={() => navigate('/contact')}
-                  className={`w-full py-3 rounded-full font-medium transition-all ${
-                    plan.popular
-                      ? 'bg-amber-400 text-gray-900 hover:shadow-lg'
-                      : 'bg-gray-100 text-gray-900 hover:bg-gray-200'
-                  }`}
-                >
-                  Get Started
-                </button>
-              </div>
-            ))}
+          {/* The upgrade path, framed simply — and the honesty line. */}
+          <div className="max-w-2xl mx-auto text-center mt-14">
+            <p className="text-gray-900 font-medium mb-3">
+              Start with Trip Pass, then move to Explore when you're ready to
+              travel more.
+            </p>
+            <p className="text-gray-500 text-sm">
+              When pricing opens, choose the one-trip option or unlock full-year
+              access with Explore.
+            </p>
           </div>
         </div>
       </section>

--- a/src/app/pages/PricingPage.tsx
+++ b/src/app/pages/PricingPage.tsx
@@ -188,13 +188,16 @@ export function PricingPage() {
               >
                 {CADENCES.map((option) => {
                   const selected = cadenceKey === option.key;
+                  // Both states give a clear hover fill (Meridian sky tints),
+                  // so the unselected cadence responds when the visitor moves
+                  // over it - not just a border change.
                   const rowClass = exploreHot
                     ? selected
                       ? 'border-sky-300 bg-sky-500/30'
-                      : 'border-sky-400 hover:border-sky-300'
+                      : 'border-sky-400 bg-sky-500/0 hover:border-sky-300 hover:bg-sky-500/20'
                     : selected
                       ? 'border-sky-600 bg-sky-600/10'
-                      : 'border-gray-300 hover:border-sky-600';
+                      : 'border-gray-300 bg-sky-600/0 hover:border-sky-600 hover:bg-sky-600/[0.06]';
                   return (
                     <button
                       key={option.key}

--- a/src/app/pages/PricingPage.tsx
+++ b/src/app/pages/PricingPage.tsx
@@ -52,7 +52,7 @@ export function PricingPage() {
             Pricing
           </p>
           <h1 className="text-4xl md:text-5xl font-bold text-gray-50 leading-tight [text-wrap:balance] max-w-3xl mb-6">
-            One trip at a time, or a year of ease?
+            Pick the plan that fits the way you travel.
           </h1>
           <p className="text-lg text-sky-100 max-w-2xl leading-relaxed">
             Trip Pass covers one trip, start to finish. Explore covers every

--- a/src/app/pages/PricingPage.tsx
+++ b/src/app/pages/PricingPage.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { ArrowRight, Check } from 'lucide-react';
+import { Check } from 'lucide-react';
 import { Link } from 'react-router-dom';
 
 // Approved offer structure (pricing handoff, 2026-07): exactly two offers.
@@ -65,37 +65,40 @@ export function PricingPage() {
       <section className="bg-gray-50">
         <div className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 py-16 md:py-20">
           <div className="grid md:grid-cols-5 gap-6 items-stretch">
-            {/* Trip Pass - the entry offer. Simpler panel, secondary action. */}
-            <div className="md:col-span-2 bg-white border border-gray-200 rounded-[14px] p-8 flex flex-col">
-              <h2 className="text-[11px] font-semibold tracking-[0.14em] uppercase text-amber-700 mb-4">
+            {/* Trip Pass - the entry offer. Explore is pre-highlighted as the
+                hero; when a visitor hovers (or keyboard-focuses into) this
+                tile, it takes on the full Explore treatment and its Sign up
+                becomes the same amber pill. Touch devices keep the quiet
+                default. */}
+            <div className="group md:col-span-2 bg-white border border-gray-200 rounded-[14px] p-8 flex flex-col transition-colors duration-200 hover:bg-sky-600 hover:border-sky-600 focus-within:bg-sky-600 focus-within:border-sky-600">
+              <h2 className="text-[11px] font-semibold tracking-[0.14em] uppercase text-amber-700 mb-4 transition-colors group-hover:text-amber-400 group-focus-within:text-amber-400">
                 Trip Pass
               </h2>
               <div className="mb-2 [font-variant-numeric:tabular-nums]">
-                <span className="text-4xl font-bold text-gray-900">$24.95</span>
-                <span className="text-gray-500 ml-2">per trip</span>
+                <span className="text-4xl font-bold text-gray-900 transition-colors group-hover:text-gray-50 group-focus-within:text-gray-50">$24.95</span>
+                <span className="text-gray-500 ml-2 transition-colors group-hover:text-sky-200 group-focus-within:text-sky-200">per trip</span>
               </div>
-              <p className="text-lg font-semibold text-gray-900 mb-6">
+              <p className="text-lg font-semibold text-gray-900 mb-6 transition-colors group-hover:text-gray-50 group-focus-within:text-gray-50">
                 One trip. Full access. No subscription required.
               </p>
               <ul className="space-y-3 mb-8">
                 {TRIP_PASS_POINTS.map((point) => (
                   <li key={point} className="flex items-start gap-3">
                     <Check
-                      className="w-4 h-4 text-sky-600 flex-shrink-0 mt-1"
+                      className="w-4 h-4 text-sky-600 flex-shrink-0 mt-1 transition-colors group-hover:text-sky-300 group-focus-within:text-sky-300"
                       strokeWidth={2}
                       aria-hidden="true"
                     />
-                    <span className="text-gray-600">{point}</span>
+                    <span className="text-gray-600 transition-colors group-hover:text-sky-100 group-focus-within:text-sky-100">{point}</span>
                   </li>
                 ))}
               </ul>
               {/* Routes to the interest form until the app/payment flow is live. */}
               <Link
                 to="/contact"
-                className="mt-auto self-start inline-flex items-center gap-1.5 py-2 font-medium text-sky-600 underline underline-offset-4 decoration-1 hover:text-sky-700 transition-colors"
+                className="mt-auto self-start px-8 py-3.5 rounded-full font-semibold border border-gray-300 text-gray-900 transition-colors group-hover:bg-amber-400 group-hover:border-amber-400 group-hover:text-gray-900 group-focus-within:bg-amber-400 group-focus-within:border-amber-400 group-focus-within:text-gray-900 hover:bg-amber-300 hover:border-amber-300"
               >
                 Sign up
-                <ArrowRight className="w-4 h-4" strokeWidth={2} aria-hidden="true" />
               </Link>
             </div>
 

--- a/src/app/pages/PricingPage.tsx
+++ b/src/app/pages/PricingPage.tsx
@@ -149,7 +149,7 @@ export function PricingPage() {
                     : 'bg-transparent border-gray-300'
                 }`}
               >
-                Sign up
+                Join Now
               </Link>
             </div>
 
@@ -290,7 +290,7 @@ export function PricingPage() {
                     : 'bg-transparent border-gray-300'
                 }`}
               >
-                Sign up
+                Join Now
               </Link>
             </div>
           </div>

--- a/src/app/pages/PricingPage.tsx
+++ b/src/app/pages/PricingPage.tsx
@@ -52,11 +52,11 @@ export function PricingPage() {
             Pricing
           </p>
           <h1 className="text-4xl md:text-5xl font-bold text-gray-50 leading-tight [text-wrap:balance] max-w-3xl mb-6">
-            Plan one trip your way, or subscribe for your next one too.
+            One trip at a time, or a year of ease?
           </h1>
           <p className="text-lg text-sky-100 max-w-2xl leading-relaxed">
-            Pay for a single trip with Trip Pass, or subscribe with Explore for
-            ongoing access and the best value.
+            Trip Pass covers one trip, start to finish. Explore covers every
+            trip, all year.
           </p>
         </div>
       </section>
@@ -176,10 +176,6 @@ export function PricingPage() {
             <p className="text-gray-900 font-medium mb-3">
               Start with Trip Pass, then move to Explore when you're ready to
               travel more.
-            </p>
-            <p className="text-gray-500 text-sm">
-              When pricing opens, choose the one-trip option or unlock full-year
-              access with Explore.
             </p>
           </div>
         </div>

--- a/src/app/pages/PricingPage.tsx
+++ b/src/app/pages/PricingPage.tsx
@@ -31,7 +31,7 @@ interface Cadence {
   best?: boolean;
 }
 
-// Single source of truth for Explore pricing — rows and the summary price
+// Single source of truth for Explore pricing - rows and the summary price
 // both render from here.
 const CADENCES: Cadence[] = [
   { key: 'annual', label: 'Annual', amount: '$99', per: 'year', best: true },
@@ -44,7 +44,7 @@ export function PricingPage() {
 
   return (
     <div className="pt-20">
-      {/* Header — flat Ateneo band. The h1 is the approved positioning line;
+      {/* Header - flat Ateneo band. The h1 is the approved positioning line;
           the subhead is the handoff's approved pricing message. */}
       <section className="bg-sky-600">
         <div className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 py-20 md:py-24">
@@ -61,11 +61,11 @@ export function PricingPage() {
         </div>
       </section>
 
-      {/* The two offers — Moonlight ground, Explore is the hero. */}
+      {/* The two offers - Moonlight ground, Explore is the hero. */}
       <section className="bg-gray-50">
         <div className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 py-16 md:py-20">
           <div className="grid md:grid-cols-5 gap-6 items-stretch">
-            {/* Trip Pass — the entry offer. Simpler panel, secondary action. */}
+            {/* Trip Pass - the entry offer. Simpler panel, secondary action. */}
             <div className="md:col-span-2 bg-white border border-gray-200 rounded-[14px] p-8 flex flex-col">
               <h2 className="text-[11px] font-semibold tracking-[0.14em] uppercase text-amber-700 mb-4">
                 Trip Pass
@@ -99,7 +99,7 @@ export function PricingPage() {
               </Link>
             </div>
 
-            {/* Explore — the hero offer, on the Ateneo panel. */}
+            {/* Explore - the hero offer, on the Ateneo panel. */}
             <div className="md:col-span-3 bg-sky-600 rounded-[14px] p-8 flex flex-col">
               <h2 className="text-[11px] font-semibold tracking-[0.14em] uppercase text-amber-400 mb-4">
                 Explore
@@ -109,7 +109,7 @@ export function PricingPage() {
                 ongoing access.
               </p>
 
-              {/* Billing cadence — two ways to pay for the same subscription. */}
+              {/* Billing cadence - two ways to pay for the same subscription. */}
               <div
                 role="group"
                 aria-label="Explore billing options"
@@ -171,7 +171,7 @@ export function PricingPage() {
             </div>
           </div>
 
-          {/* The upgrade path, framed simply — and the honesty line. */}
+          {/* The upgrade path, framed simply - and the honesty line. */}
           <div className="max-w-2xl mx-auto text-center mt-14">
             <p className="text-gray-900 font-medium mb-3">
               Start with Trip Pass, then move to Explore when you're ready to


### PR DESCRIPTION
## What

First page of the NINE redesign execution. The pricing page's three invented tiers — Explorer \$9.99 / Adventurer \$19.99 / Globetrotter \$39.99, with invented benefits ("travel insurance discounts", "concierge phone support"), a "Most Popular" badge with zero customers, and a "Start free" promise with no free tier — are replaced by the approved two-offer structure from the pricing handoff:

| | Trip Pass | Explore (hero) |
|---|---|---|
| Price | **\$24.95** per trip | **\$99/yr** (Best value) · **\$11.95/mo** |
| Line | "One trip. Full access. No subscription required." | "The full JarvisTravel subscription for travelers who want ongoing access." |

- Annual and Monthly are presented as **billing cadences of one subscription**, never separate tiers. **Quarterly is deliberately omitted** and there is **no waitlist/founding pricing** — both brand-owner calls recorded on JAR-430.
- Bullet copy is the handoff's card language **verbatim**. "Best value" (factual), never "Most Popular" (zero customers).
- Upgrade path framed only via the approved line; no credit/refund/billing mechanics.
- Closing honesty line: *"When pricing opens, choose the one-trip option or unlock full-year access with Explore."* — nothing implies you can purchase today.
- CTAs are **"Sign up"** router Links → the interest form for now, the app/payment flow when it's hooked up (matches the sitewide rename on PR #26).

## Design

NINE language: flat Ateneo header band (approved positioning line as the h1), Moonlight ground, white + Ateneo raised panels with hairline borders, zero gradients/orbs/shadows, one solid amber per section, tinted amber "Best value" pill (the app's tint recipe), lucide `Check`/`ArrowRight` at explicit stroke in the voice colour, tabular numerals on every price.

## Adversarial review already applied

A 3-agent panel (handoff compliance / brand / a11y) reviewed the first draft; all blockers fixed before this PR:
- "Annual is the lowest-priced Explore option" read as **factually false** next to \$11.95/mo → replaced with the approved value line.
- "Best value" chip was a **second solid amber** in the CTA's section → now the tinted pill.
- `role="radio"` without arrow-key support **misled screen readers** → plain `aria-pressed` toggle buttons in a labeled group.
- Cadence-row borders failed 3:1 non-text contrast (`white/15` ≈ 1.5:1) → sky-ramp borders (≥4:1).
- Navigation-as-button → router `Link`s; prices now render from a single source of truth.

## Verification

`npm run lint` clean · `tsc --noEmit` clean · `check-plan-not-book` passes · `vite build` green. Visually verified desktop + 375px mobile (no horizontal overflow); cadence toggle exercised.

🤖 Generated with [Claude Code](https://claude.com/claude-code)