### PR TITLE
feat(JAR-431): rebuild home page — NINE structure, honest content, app icon language

### DIFF
--- a/src/app/pages/HomePage.tsx
+++ b/src/app/pages/HomePage.tsx
@@ -13,7 +13,9 @@ import type { LucideIcon } from 'lucide-react';
 // Home (JAR-431). Benefit-led story per the jarvistravel-copy voice skill:
 // what a traveler misses without JarvisTravel and what planning wrong costs.
 // The Fatigue Index deep-dive lives on /features; FI appears here only as a
-// benefit, always in digits (1 to 9). No em dashes anywhere (brand rule).
+// benefit, in the app's band words (chill, balanced, packed) since raw
+// numbers mean nothing to a first-time visitor. Digits appear only on the
+// How it works explainer. No em dashes anywhere (brand rule).
 //
 // The hero rotates: one of five approved headline pairs is picked per visit,
 // so two visitors may see different messaging (lightweight A/B signal).
@@ -40,7 +42,7 @@ const HEROES: Hero[] = [
   },
   {
     headline: 'Come home with stories, not exhaustion.',
-    sub: 'Jarvis rates every day of your plan 1 to 9, so the hard days show up before you do.',
+    sub: 'Jarvis reads every day of your plan as chill, balanced, or packed, so the tough ones show up before you do.',
   },
   {
     headline: 'Twelve tabs is not a travel plan.',
@@ -67,7 +69,7 @@ const FEATURES: Feature[] = [
   {
     icon: TrendingUp,
     name: 'The Fatigue Index',
-    desc: 'Every day rated 1 to 9 before you commit, so the hard days show up while you can still fix them.',
+    desc: 'Every day reads chill, balanced, or packed before you commit, so the tough days show up while you can still fix them.',
     voice: 'accent',
   },
   {
@@ -165,10 +167,11 @@ export function HomePage() {
             you come home needing a vacation from the vacation.
           </p>
           <p className="text-lg text-gray-600 leading-relaxed mb-8">
-            Jarvis rates every day of your plan from 1 to 9 while you build it.
-            When a day hits 7, you&rsquo;ll know before you&rsquo;re standing in
-            it, and Jarvis offers a lighter version of the same day. Fixing it
-            takes one tap instead of a family argument.
+            Jarvis reads every day of your plan while you build it and calls it
+            what it is: chill, balanced, or packed. When a day comes up packed,
+            you&rsquo;ll know before you&rsquo;re standing in it, and Jarvis
+            offers a lighter version of the same day. Fixing it takes one tap
+            instead of a family argument.
           </p>
           <Link
             to="/features"

--- a/src/app/pages/HomePage.tsx
+++ b/src/app/pages/HomePage.tsx
@@ -9,6 +9,7 @@ import {
 } from 'lucide-react';
 import { Link } from 'react-router-dom';
 import type { LucideIcon } from 'lucide-react';
+import { useImage, imageSrcSet } from '../utils/imagery';
 
 // Home (JAR-431). Benefit-led story per the jarvistravel-copy voice skill:
 // what a traveler misses without JarvisTravel and what planning wrong costs.
@@ -50,12 +51,13 @@ const HEROES: Hero[] = [
   },
 ];
 
-// Photography slot for the "Not just the big trip" band. Set this to a real
-// golden-hour, people-in-place frame (self-hosted in public/) once a shoot or
-// licensed image lands - see the photography sourcing decision. Leaving it
-// null renders the designed navy-and-motif fallback, so the site never ships
-// an empty frame or off-brand stock.
-const BREADTH_PHOTO: { src: string; alt: string } | null = null;
+// The "Not just the big trip" band pulls a golden-hour travel photo the same
+// way the app does - the Pexels integration (see utils/imagery). With no
+// VITE_PEXELS_API_KEY the lookup returns nothing and the band renders its
+// designed navy-and-motif fallback, so the site never ships an empty frame.
+const BREADTH_QUERY = 'golden hour city travel walking';
+const BREADTH_ALT =
+  'Travelers walking a sunlit street at golden hour.';
 
 interface Feature {
   icon: LucideIcon;
@@ -135,6 +137,9 @@ export function HomePage() {
   const [hero] = useState<Hero>(
     () => HEROES[Math.floor(Math.random() * HEROES.length)]
   );
+  // Undefined until (and unless) a Pexels key yields a photo; the band falls
+  // back to its navy treatment when this stays undefined.
+  const breadthPhoto = useImage(BREADTH_QUERY, undefined);
 
   return (
     <div>
@@ -189,23 +194,23 @@ export function HomePage() {
         </div>
       </section>
 
-      {/* Every trip counts, as a full-bleed editorial band. Photo-ready: drop
-          a golden-hour frame into BREADTH_PHOTO and it renders full-bleed
-          under the ratified Neverything scrim. Until then the band stands on
-          its own as the designed navy-and-motif fallback. */}
+      {/* Every trip counts, as a full-bleed editorial band. A Pexels photo
+          loads under the ratified Neverything scrim when a key is set;
+          otherwise the band is the designed navy-and-motif fallback. */}
       <section className="relative overflow-hidden bg-sky-600 min-h-[46vh] flex items-center">
-        {BREADTH_PHOTO && (
+        {breadthPhoto ? (
           <>
             <img
-              src={BREADTH_PHOTO.src}
-              alt={BREADTH_PHOTO.alt}
+              src={breadthPhoto}
+              srcSet={imageSrcSet(breadthPhoto)}
+              sizes="100vw"
+              alt={BREADTH_ALT}
               className="absolute inset-0 w-full h-full object-cover"
             />
             {/* The one ratified gradient: single-hue Neverything scrim. */}
             <div className="absolute inset-0 bg-gradient-to-t from-[#13181B]/85 via-[#13181B]/45 to-[#13181B]/35" />
           </>
-        )}
-        {!BREADTH_PHOTO && (
+        ) : (
           <>
             <ContourArcs className="absolute -top-40 -left-40 w-[520px] h-[520px]" />
             <ContourArcs className="absolute -bottom-52 -right-36 w-[520px] h-[520px]" />

--- a/src/app/pages/HomePage.tsx
+++ b/src/app/pages/HomePage.tsx
@@ -182,6 +182,20 @@ export function HomePage() {
         </div>
       </section>
 
+      {/* Every trip counts: the app is not just for the one big trip a year. */}
+      <section className="bg-white">
+        <div className="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8 pt-16 md:pt-20">
+          <h2 className="text-3xl md:text-4xl font-bold text-gray-900 [text-wrap:balance] mb-6">
+            Not just the big trip.
+          </h2>
+          <p className="text-lg text-gray-600 leading-relaxed">
+            A long weekend, a staycation, two weeks abroad, a road trip an hour
+            from home. If it has days, Jarvis plans them: the pace, the budget,
+            the map, the memories.
+          </p>
+        </div>
+      </section>
+
       {/* What you get: the product, in benefit language. */}
       <section className="bg-white">
         <div className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 py-16 md:py-20">

--- a/src/app/pages/HomePage.tsx
+++ b/src/app/pages/HomePage.tsx
@@ -183,18 +183,41 @@ export function HomePage() {
         </div>
       </section>
 
-      {/* Why you can trust the plan — differentiation as benefit. */}
+      {/* Why you can trust the plan — three promises, in plain speak
+          (voice per the jarvistravel-copy skill). */}
       <section className="bg-gray-50">
         <div className="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8 py-16 md:py-20">
-          <h2 className="text-3xl md:text-4xl font-bold text-gray-900 [text-wrap:balance] mb-6">
-            Advice that&rsquo;s on your side.
+          <h2 className="text-3xl md:text-4xl font-bold text-gray-900 [text-wrap:balance] mb-10">
+            Three promises.
           </h2>
-          <p className="text-lg text-gray-600 leading-relaxed">
-            When Jarvis suggests a place, it&rsquo;s because it fits your day —
-            never because someone paid for the spot. No ads, no commissions, no
-            sponsored detours. And the trip you take stays yours: the journal,
-            the photos and the places belong to you, not to an algorithm.
-          </p>
+          <ul className="border-t border-gray-200">
+            <li className="py-6 border-b border-gray-200">
+              <h3 className="text-xl font-semibold text-gray-900 mb-2">
+                Nobody pays to be in your plan.
+              </h3>
+              <p className="text-gray-600 leading-relaxed">
+                Every suggestion is there because it fits your trip — never
+                because a hotel or tour paid us.
+              </p>
+            </li>
+            <li className="py-6 border-b border-gray-200">
+              <h3 className="text-xl font-semibold text-gray-900 mb-2">
+                No ads, ever.
+              </h3>
+              <p className="text-gray-600 leading-relaxed">
+                Your plan isn&rsquo;t a billboard.
+              </p>
+            </li>
+            <li className="py-6 border-b border-gray-200">
+              <h3 className="text-xl font-semibold text-gray-900 mb-2">
+                Your memories belong to you.
+              </h3>
+              <p className="text-gray-600 leading-relaxed">
+                Your journal — the notes, the photos, the places — is yours. We
+                never sell it.
+              </p>
+            </li>
+          </ul>
         </div>
       </section>
 

--- a/src/app/pages/HomePage.tsx
+++ b/src/app/pages/HomePage.tsx
@@ -2,7 +2,6 @@ import {
   BookOpen,
   CloudSun,
   Map as MapIcon,
-  Plane,
   Sparkles,
   TrendingUp,
   Wallet,
@@ -10,109 +9,59 @@ import {
 import { Link } from 'react-router-dom';
 import type { LucideIcon } from 'lucide-react';
 
-// NINE interim home page (JAR-431). Asset-light by design: no photography and
-// no app captures yet, so the page rests on the two things that are real —
-// the shipped 1–9 Fatigue Index and honest copy. Every factual claim below
-// maps to shipped code; the five inputs are the engine's FATIGUE_WEIGHTS
-// keys, and the dial uses the app's FI ramp hexes verbatim.
-//
-// Removed relative to the old page (audit findings): fabricated stats and
-// testimonials framing, gradient hero + blur orbs + noise texture, gradient
-// icon tiles wearing data-palette colors as chrome, min-h-screen hero,
-// unbuilt-feature claims (bank sync, receipt scanning, group voting, 24/7,
-// "sleep patterns" — restPeriods is not sleep debt).
+// Home (JAR-431, reworked per brand-owner direction 2026-07-21): this page
+// tells the story — what a traveler misses without JarvisTravel and what
+// planning wrong costs — in benefit language. The Fatigue Index deep-dive
+// (mechanics, inputs, the dial) lives on /features; here FI appears only as
+// a benefit, always written with numeric digits (1–9, 7), never spelled out.
+// The numbered section eyebrows were retired sitewide: they read like slides.
+// Every factual claim still maps to shipped code.
 
-interface FiInput {
-  name: string;
-  desc: string;
-}
-
-// The five engine inputs (FATIGUE_WEIGHTS): jetLag, travelTime,
-// walkingDistance, activityDensity, restPeriods.
-const FI_INPUTS: FiInput[] = [
-  { name: 'Time-zone shift', desc: 'How far your body clock has to move.' },
-  { name: 'Hours in transit', desc: 'Flights, trains, transfers — the time spent getting there.' },
-  { name: 'Walking distance', desc: 'The miles a day actually asks of you.' },
-  { name: 'Day density', desc: 'How much is packed in, and how tightly.' },
-  { name: 'Downtime', desc: 'How much recovery the day leaves you.' },
-];
-
-interface Restraint {
-  name: string;
-  desc: string;
-}
-
-// Three restraints, not four: the fourth slot requires a measured claim and
-// nothing is measured yet. Refusing to fill the grid is the point.
-const RESTRAINTS: Restraint[] = [
-  {
-    name: 'No commissions.',
-    desc: 'We’re not a seller of travel, and no company that appears in your plan pays us anything to appear there.',
-  },
-  {
-    name: 'No ads.',
-    desc: 'The product has no slot for one — now, or at scale.',
-  },
-  {
-    // "never used to train anyone's model" is held back until the Privacy
-    // Policy states it in writing — a published commitment must match the
-    // policy word for word. Restore alongside the legal-pages phase.
-    name: 'Your journal is yours.',
-    desc: 'Entries, photos and locations are yours, and they are never sold.',
-  },
-];
-
-interface ProductRow {
+interface Feature {
   icon: LucideIcon;
   name: string;
   desc: string;
   voice: 'accent' | 'journal';
 }
 
-// Shipped features only. Icons follow the app's row recipe: a w-9 tinted
-// voice container with the glyph drawn in the voice color — coral belongs to
-// the journal and appears nowhere else.
-const PRODUCT_ROWS: ProductRow[] = [
-  {
-    icon: TrendingUp,
-    name: 'The Fatigue Index',
-    desc: 'Every day of your plan scored one to nine, so the hard days show up before you commit.',
-    voice: 'accent',
-  },
+// Shipped features only, written as benefits. Icons follow the app's row
+// recipe — tinted voice containers, glyph in the voice color; coral belongs
+// to the journal and appears nowhere else.
+const FEATURES: Feature[] = [
   {
     icon: Sparkles,
     name: 'Trip planning',
-    desc: 'Jarvis drafts the days — pacing, order, and the walk between stops. You decide.',
+    desc: 'Jarvis drafts your days around your pace and the daylight you actually have. You decide; it does the homework.',
+    voice: 'accent',
+  },
+  {
+    icon: TrendingUp,
+    name: 'The Fatigue Index',
+    desc: 'Every day rated 1–9 before you commit, so the hard days show up while you can still fix them.',
     voice: 'accent',
   },
   {
     icon: Wallet,
     name: 'Budget',
-    desc: 'A budget that sits inside the plan: categories, running totals, what’s left.',
+    desc: 'Totals that move while you plan — not a surprise after you land back home.',
     voice: 'accent',
   },
   {
     icon: BookOpen,
     name: 'Trip journal',
-    desc: 'Notes, photos, receipts and places, kept together and worth rereading.',
+    desc: 'Notes, photos, receipts and places become a story worth rereading — yours to keep.',
     voice: 'journal',
   },
   {
     icon: MapIcon,
     name: 'The map',
-    desc: 'Your trip on one map, numbered by day.',
+    desc: 'Your whole trip on one map, numbered by day, with the walk between stops visible.',
     voice: 'accent',
   },
   {
     icon: CloudSun,
-    name: 'Weather',
-    desc: 'Seven days out, plus what the season usually does there.',
-    voice: 'accent',
-  },
-  {
-    icon: Plane,
-    name: 'Flights',
-    desc: 'Your flights, tracked inside the plan.',
+    name: 'Weather & flights',
+    desc: 'The forecast and your flights sit inside the plan — fewer surprises, fewer tabs.',
     voice: 'accent',
   },
 ];
@@ -142,222 +91,124 @@ function ContourArcs({ className }: { className: string }) {
   );
 }
 
-/** The Fatigue Index dial — the shipped 1–9 ramp, drawn exactly.
- *  Not an app screenshot: a brand instrument rendering the real scale.
- *  Hexes are the app's DARK-ground ramp tokens (index.css --fi-* dark set) —
- *  the dial sits on navy, and the light-set red reads under 3:1 there.
- *  The figcaption is the text alternative; the drawing itself is aria-hidden
- *  so screen readers hear the reading once, not twice. */
-function FiDial() {
-  return (
-    <figure className="mx-auto max-w-[340px]">
-      <svg viewBox="0 0 200 200" aria-hidden="true">
-        <g fill="none">
-          <circle cx="100" cy="100" r="30" stroke="#38BDF8" strokeWidth="2.5" opacity="0.85" />
-          <circle cx="100" cy="100" r="37" stroke="#38BDF8" strokeWidth="2.5" opacity="0.85" />
-          <circle cx="100" cy="100" r="44" stroke="#38BDF8" strokeWidth="2.5" opacity="0.85" />
-          <circle cx="100" cy="100" r="51" stroke="#34D399" strokeWidth="3" opacity="0.9" />
-          <circle cx="100" cy="100" r="58" stroke="#34D399" strokeWidth="3" opacity="0.9" />
-          <circle cx="100" cy="100" r="65" stroke="#34D399" strokeWidth="3" opacity="0.9" />
-          <circle cx="100" cy="100" r="72" stroke="#FBBF24" strokeWidth="4" />
-          <circle cx="100" cy="100" r="79" stroke="#FBBF24" strokeWidth="4" />
-          <circle cx="100" cy="100" r="88" stroke="#F07668" strokeWidth="5" />
-          <line x1="100" y1="100" x2="100" y2="12" stroke="#F0EEEB" strokeOpacity="0.3" strokeWidth="1" />
-        </g>
-        <text
-          x="100"
-          y="100"
-          textAnchor="middle"
-          dominantBaseline="central"
-          fill="#F0EEEB"
-          fontSize="42"
-          fontWeight="700"
-          style={{ fontVariantNumeric: 'tabular-nums' }}
-        >
-          7
-        </text>
-      </svg>
-      <figcaption className="mt-4 text-[13px] text-sky-200 text-center">
-        The Fatigue Index. Every day scored, one to nine — seven is a day
-        you&rsquo;ll feel.
-      </figcaption>
-    </figure>
-  );
-}
-
 export function HomePage() {
   return (
     <div>
-      {/* 01 — The number. Flat Ateneo, no photograph: the scale is the image. */}
+      {/* Hero — the story, not the mechanics. */}
       <section className="relative overflow-hidden bg-sky-600">
         <ContourArcs className="absolute -top-44 -left-44 w-[520px] h-[520px]" />
         <ContourArcs className="absolute -bottom-56 -right-40 w-[520px] h-[520px]" />
-        <div className="relative max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 pt-32 pb-20 md:pt-40 md:pb-28">
-          <div className="grid lg:grid-cols-12 gap-12 lg:gap-8 items-center">
-            <div className="lg:col-span-7">
-              <p className="text-[11px] font-semibold tracking-[0.14em] uppercase text-amber-400 mb-6 [font-variant-numeric:tabular-nums]">
-                01 — The Fatigue Index
-              </p>
-              <h1 className="text-4xl md:text-5xl font-bold text-gray-50 leading-tight [text-wrap:balance] mb-6">
-                Nine is a hard day.
-              </h1>
-              <p className="text-lg md:text-xl text-sky-100 leading-relaxed max-w-xl mb-4">
-                JarvisTravel scores every day of a trip from one to nine. It
-                reads how far your body clock will move, how long you&rsquo;ll be
-                in transit, how far you&rsquo;ll walk, how densely the day is
-                packed, and how much downtime it leaves you. One is easy. Nine
-                you will feel.
-              </p>
-              <p className="text-sm text-sky-200 mb-10">
-                Planning only. We take no commissions, and we&rsquo;re not a
-                seller of travel.
-              </p>
-              {/* Routes to the interest form until the app/payment flow is live. */}
-              <Link
-                to="/contact"
-                className="inline-block px-8 py-4 bg-amber-400 text-gray-900 rounded-full font-semibold hover:bg-amber-300 transition-colors"
-              >
-                Sign up
-              </Link>
-            </div>
-            <div className="lg:col-span-5">
-              <FiDial />
-            </div>
-          </div>
-        </div>
-      </section>
-
-      {/* 02 — The belief. Tight, no image, no CTA: a belief with a button
-          attached stops being a belief. */}
-      <section className="bg-gray-50">
-        <div className="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8 py-16 md:py-20">
-          <p className="text-[11px] font-semibold tracking-[0.14em] uppercase text-amber-700 mb-6 [font-variant-numeric:tabular-nums]">
-            02 — Why it works this way
+        <div className="relative max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 pt-36 pb-24 md:pt-44 md:pb-32 text-center">
+          <h1 className="text-4xl md:text-5xl font-bold text-gray-50 leading-tight [text-wrap:balance] mb-6">
+            Your vacation should be a break, not a second job.
+          </h1>
+          <p className="text-lg md:text-xl text-sky-100 leading-relaxed max-w-2xl mx-auto mb-10">
+            JarvisTravel plans the pace, the budget and the map in one place —
+            so the trip you take feels like the trip you imagined.
           </p>
-          <h2 className="text-3xl md:text-4xl font-bold text-gray-900 [text-wrap:balance] mb-6">
-            We started from the end of the day.
-          </h2>
-          <p className="text-lg text-gray-600 leading-relaxed">
-            Twelve tabs, a shared spreadsheet and a map full of pins will get
-            you a plan. What none of them will tell you is whether Thursday is
-            survivable. So we built the pacing model first and hung the
-            itinerary off it — because the failure everyone recognizes is not a
-            museum you missed. It&rsquo;s standing somewhere you spent a year
-            wanting to be, too tired to want it.
-          </p>
-        </div>
-      </section>
-
-      {/* 03 — How the number is made. The dial's chapter carries no CTA. */}
-      <section className="relative overflow-hidden bg-sky-600">
-        <ContourArcs className="absolute -top-52 -right-44 w-[520px] h-[520px]" />
-        <div className="relative max-w-3xl mx-auto px-4 sm:px-6 lg:px-8 py-20 md:py-24">
-          <p className="text-[11px] font-semibold tracking-[0.14em] uppercase text-amber-400 mb-6 [font-variant-numeric:tabular-nums]">
-            03 — How the number is made
-          </p>
-          <h2 className="text-3xl md:text-4xl font-bold text-gray-50 [text-wrap:balance] mb-6">
-            Where the number comes from.
-          </h2>
-          <p className="text-lg text-sky-100 leading-relaxed mb-10">
-            Five inputs, weighted. Out comes one number, one to nine. At seven
-            and above, Jarvis flags the day before you commit and offers a
-            lighter version of the same day.
-          </p>
-          <ul className="border-t border-white/15">
-            {FI_INPUTS.map((input) => (
-              <li
-                key={input.name}
-                className="grid sm:grid-cols-[180px_1fr] gap-1 sm:gap-6 py-4 border-b border-white/15"
-              >
-                <span className="font-medium text-gray-50">{input.name}</span>
-                <span className="text-sky-200">{input.desc}</span>
-              </li>
-            ))}
-          </ul>
-          <p className="mt-8 text-sm text-sky-200">
-            It describes what the day costs, not what it cures — a pacing
-            model, not medical advice.
-          </p>
-        </div>
-      </section>
-
-      {/* 04 — Restraints. The honest replacement for the old stat bar. */}
-      <section className="bg-gray-50">
-        <div className="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8 py-20 md:py-24">
-          <p className="text-[11px] font-semibold tracking-[0.14em] uppercase text-amber-700 mb-6 [font-variant-numeric:tabular-nums]">
-            04 — Restraints
-          </p>
-          <h2 className="text-3xl md:text-4xl font-bold text-gray-900 [text-wrap:balance] mb-10">
-            Three things it will never do.
-          </h2>
-          <ul className="border-t border-gray-200">
-            {RESTRAINTS.map((item) => (
-              <li key={item.name} className="py-6 border-b border-gray-200">
-                <h3 className="text-xl font-semibold text-gray-900 mb-2">{item.name}</h3>
-                <p className="text-gray-600 leading-relaxed">{item.desc}</p>
-              </li>
-            ))}
-          </ul>
           {/* Routes to the interest form until the app/payment flow is live. */}
           <Link
             to="/contact"
-            className="inline-block mt-10 px-8 py-4 bg-amber-400 text-gray-900 rounded-full font-semibold hover:bg-amber-300 transition-colors"
+            className="inline-block px-8 py-4 bg-amber-400 text-gray-900 rounded-full font-semibold hover:bg-amber-300 transition-colors"
           >
             Sign up
           </Link>
         </div>
       </section>
 
-      {/* 05 — What's in the product. Shipped features only; the app's icon
-          row recipe (tinted voice container, glyph in the voice color). */}
-      <section className="bg-white">
-        <div className="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8 py-20 md:py-24">
-          <p className="text-[11px] font-semibold tracking-[0.14em] uppercase text-amber-700 mb-6 [font-variant-numeric:tabular-nums]">
-            05 — What&rsquo;s in the product
-          </p>
-          <h2 className="text-3xl md:text-4xl font-bold text-gray-900 [text-wrap:balance] mb-10">
-            What Jarvis does today.
+      {/* The cost of planning wrong — what you miss without it. */}
+      <section className="bg-gray-50">
+        <div className="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8 py-16 md:py-20">
+          <h2 className="text-3xl md:text-4xl font-bold text-gray-900 [text-wrap:balance] mb-6">
+            The trip you waited a year for shouldn&rsquo;t wear you out by
+            Tuesday.
           </h2>
-          <ul className="border-t border-gray-200">
-            {PRODUCT_ROWS.map((row) => {
-              const Icon = row.icon;
+          <p className="text-lg text-gray-600 leading-relaxed mb-6">
+            Twelve tabs and a shared spreadsheet will get you a plan — but they
+            won&rsquo;t tell you that day 2 has six hours of walking after a
+            red-eye, or that the museum, the market and the dinner across town
+            don&rsquo;t fit in the same afternoon. That&rsquo;s the trip where
+            you come home needing a vacation from the vacation.
+          </p>
+          <p className="text-lg text-gray-600 leading-relaxed mb-8">
+            Jarvis rates every day of your plan from 1 to 9 while you build it.
+            When a day hits 7, you&rsquo;ll know before you&rsquo;re standing in
+            it — and Jarvis offers a lighter version of the same day, so fixing
+            it takes one tap instead of a family argument.
+          </p>
+          <Link
+            to="/features"
+            className="font-medium text-sky-600 underline underline-offset-4 decoration-1 hover:text-sky-700 transition-colors"
+          >
+            See how it works
+          </Link>
+        </div>
+      </section>
+
+      {/* What you get — the product, in benefit language. */}
+      <section className="bg-white">
+        <div className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 py-16 md:py-20">
+          <div className="max-w-2xl mb-12">
+            <h2 className="text-3xl md:text-4xl font-bold text-gray-900 [text-wrap:balance] mb-4">
+              One plan, instead of twelve tabs.
+            </h2>
+            <p className="text-lg text-gray-600 leading-relaxed">
+              Everything that makes a trip work — and everything you&rsquo;d
+              rather not juggle — in one place.
+            </p>
+          </div>
+          <div className="grid sm:grid-cols-2 lg:grid-cols-3 gap-6">
+            {FEATURES.map((feature) => {
+              const Icon = feature.icon;
               return (
-                <li key={row.name} className="flex items-start gap-4 py-5 border-b border-gray-200">
+                <div
+                  key={feature.name}
+                  className="bg-gray-50 border border-gray-200 rounded-[14px] p-6"
+                >
                   <span
-                    className={`w-9 h-9 rounded-lg flex items-center justify-center flex-shrink-0 ${
-                      row.voice === 'journal'
+                    className={`w-9 h-9 rounded-lg flex items-center justify-center mb-4 ${
+                      feature.voice === 'journal'
                         ? 'bg-coral-600/10 text-coral-600'
                         : 'bg-sky-600/10 text-sky-600'
                     }`}
                   >
                     <Icon className="w-5 h-5" strokeWidth={2} aria-hidden="true" />
                   </span>
-                  <div>
-                    <h3 className="font-semibold text-gray-900">{row.name}</h3>
-                    <p className="text-gray-600">{row.desc}</p>
-                  </div>
-                </li>
+                  <h3 className="font-semibold text-gray-900 mb-2">{feature.name}</h3>
+                  <p className="text-gray-600 leading-relaxed">{feature.desc}</p>
+                </div>
               );
             })}
-          </ul>
+          </div>
         </div>
       </section>
 
-      {/* The invitation — deliberately unnumbered: it is not a chapter, and
-          ending the count on nine (our own definition of a hard day) would
-          teach the wrong thing. The only centered section on the page. */}
+      {/* Why you can trust the plan — differentiation as benefit. */}
+      <section className="bg-gray-50">
+        <div className="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8 py-16 md:py-20">
+          <h2 className="text-3xl md:text-4xl font-bold text-gray-900 [text-wrap:balance] mb-6">
+            Advice that&rsquo;s on your side.
+          </h2>
+          <p className="text-lg text-gray-600 leading-relaxed">
+            When Jarvis suggests a place, it&rsquo;s because it fits your day —
+            never because someone paid for the spot. No ads, no commissions, no
+            sponsored detours. And the trip you take stays yours: the journal,
+            the photos and the places belong to you, not to an algorithm.
+          </p>
+        </div>
+      </section>
+
+      {/* The invitation. */}
       <section className="relative overflow-hidden bg-slate-900">
         <ContourArcs className="absolute -top-40 -left-48 w-[520px] h-[520px]" />
         <ContourArcs className="absolute -bottom-52 -right-44 w-[520px] h-[520px]" />
         <div className="relative max-w-2xl mx-auto px-4 sm:px-6 lg:px-8 py-20 md:py-28 text-center">
-          <p className="text-[11px] font-semibold tracking-[0.14em] uppercase text-amber-400 mb-6">
-            Early access
-          </p>
           <h2 className="text-3xl md:text-4xl font-bold text-gray-50 [text-wrap:balance] mb-4">
-            Come plan something slow.
+            Enjoy your vacation.
           </h2>
           <p className="text-lg text-sky-100 mb-10">
-            Sign up to be the first to know when we launch.
+            Planning is hard. Jarvis does the heavy lifting — sign up and be
+            first in when we launch.
           </p>
           {/* Routes to the interest form until the app/payment flow is live. */}
           <Link

--- a/src/app/pages/HomePage.tsx
+++ b/src/app/pages/HomePage.tsx
@@ -267,7 +267,7 @@ export function HomePage() {
           </h2>
           <p className="text-lg text-sky-100 mb-10">
             Planning is hard. Jarvis does the heavy lifting. Sign up and be
-            first in when we launch.
+            the first to know when we launch.
           </p>
           {/* Routes to the interest form until the app/payment flow is live. */}
           <Link

--- a/src/app/pages/HomePage.tsx
+++ b/src/app/pages/HomePage.tsx
@@ -154,7 +154,7 @@ export function HomePage() {
             to="/contact"
             className="inline-block px-8 py-4 bg-amber-400 text-gray-900 rounded-full font-semibold hover:bg-amber-300 transition-colors"
           >
-            Sign up
+            Join Now
           </Link>
         </div>
       </section>
@@ -314,7 +314,7 @@ export function HomePage() {
             to="/contact"
             className="inline-block px-10 py-4 bg-amber-400 text-gray-900 rounded-full font-semibold hover:bg-amber-300 transition-colors"
           >
-            Sign up
+            Join Now
           </Link>
         </div>
       </section>

--- a/src/app/pages/HomePage.tsx
+++ b/src/app/pages/HomePage.tsx
@@ -1,276 +1,371 @@
-import { useEffect, useState } from 'react';
 import {
+  BookOpen,
+  CloudSun,
+  Map as MapIcon,
+  Plane,
   Sparkles,
   TrendingUp,
-  CreditCard,
-  Users,
-  Camera,
-  MessageCircle,
-  ChevronDown,
-  Award,
-  CheckCircle,
+  Wallet,
 } from 'lucide-react';
-import { useNavigate } from 'react-router-dom';
+import { Link } from 'react-router-dom';
 import type { LucideIcon } from 'lucide-react';
 
-interface Feature {
-  icon: LucideIcon;
-  title: string;
+// NINE interim home page (JAR-431). Asset-light by design: no photography and
+// no app captures yet, so the page rests on the two things that are real —
+// the shipped 1–9 Fatigue Index and honest copy. Every factual claim below
+// maps to shipped code; the five inputs are the engine's FATIGUE_WEIGHTS
+// keys, and the dial uses the app's FI ramp hexes verbatim.
+//
+// Removed relative to the old page (audit findings): fabricated stats and
+// testimonials framing, gradient hero + blur orbs + noise texture, gradient
+// icon tiles wearing data-palette colors as chrome, min-h-screen hero,
+// unbuilt-feature claims (bank sync, receipt scanning, group voting, 24/7,
+// "sleep patterns" — restPeriods is not sleep debt).
+
+interface FiInput {
+  name: string;
   desc: string;
-  color: string;
 }
 
-interface Stat {
-  value: string;
-  label: string;
+// The five engine inputs (FATIGUE_WEIGHTS): jetLag, travelTime,
+// walkingDistance, activityDensity, restPeriods.
+const FI_INPUTS: FiInput[] = [
+  { name: 'Time-zone shift', desc: 'How far your body clock has to move.' },
+  { name: 'Hours in transit', desc: 'Flights, trains, transfers — the time spent getting there.' },
+  { name: 'Walking distance', desc: 'The miles a day actually asks of you.' },
+  { name: 'Day density', desc: 'How much is packed in, and how tightly.' },
+  { name: 'Downtime', desc: 'How much recovery the day leaves you.' },
+];
+
+interface Restraint {
+  name: string;
+  desc: string;
+}
+
+// Three restraints, not four: the fourth slot requires a measured claim and
+// nothing is measured yet. Refusing to fill the grid is the point.
+const RESTRAINTS: Restraint[] = [
+  {
+    name: 'No commissions.',
+    desc: 'We’re not a seller of travel, and no company that appears in your plan pays us anything to appear there.',
+  },
+  {
+    name: 'No ads.',
+    desc: 'The product has no slot for one — now, or at scale.',
+  },
+  {
+    // "never used to train anyone's model" is held back until the Privacy
+    // Policy states it in writing — a published commitment must match the
+    // policy word for word. Restore alongside the legal-pages phase.
+    name: 'Your journal is yours.',
+    desc: 'Entries, photos and locations are yours, and they are never sold.',
+  },
+];
+
+interface ProductRow {
+  icon: LucideIcon;
+  name: string;
+  desc: string;
+  voice: 'accent' | 'journal';
+}
+
+// Shipped features only. Icons follow the app's row recipe: a w-9 tinted
+// voice container with the glyph drawn in the voice color — coral belongs to
+// the journal and appears nowhere else.
+const PRODUCT_ROWS: ProductRow[] = [
+  {
+    icon: TrendingUp,
+    name: 'The Fatigue Index',
+    desc: 'Every day of your plan scored one to nine, so the hard days show up before you commit.',
+    voice: 'accent',
+  },
+  {
+    icon: Sparkles,
+    name: 'Trip planning',
+    desc: 'Jarvis drafts the days — pacing, order, and the walk between stops. You decide.',
+    voice: 'accent',
+  },
+  {
+    icon: Wallet,
+    name: 'Budget',
+    desc: 'A budget that sits inside the plan: categories, running totals, what’s left.',
+    voice: 'accent',
+  },
+  {
+    icon: BookOpen,
+    name: 'Trip journal',
+    desc: 'Notes, photos, receipts and places, kept together and worth rereading.',
+    voice: 'journal',
+  },
+  {
+    icon: MapIcon,
+    name: 'The map',
+    desc: 'Your trip on one map, numbered by day.',
+    voice: 'accent',
+  },
+  {
+    icon: CloudSun,
+    name: 'Weather',
+    desc: 'Seven days out, plus what the season usually does there.',
+    voice: 'accent',
+  },
+  {
+    icon: Plane,
+    name: 'Flights',
+    desc: 'Your flights, tracked inside the plan.',
+    voice: 'accent',
+  },
+];
+
+/** Concentric contour rings — the Meridian motif, Moonlight at 13% on navy.
+ *  pointer-events-none so the overlay can never intercept clicks on content. */
+function ContourArcs({ className }: { className: string }) {
+  return (
+    <svg
+      className={`pointer-events-none ${className}`}
+      viewBox="0 0 520 520"
+      fill="none"
+      aria-hidden="true"
+    >
+      {[130, 170, 210, 250].map((r) => (
+        <circle
+          key={r}
+          cx="260"
+          cy="260"
+          r={r}
+          stroke="#F0EEEB"
+          strokeOpacity="0.13"
+          strokeWidth="1"
+        />
+      ))}
+    </svg>
+  );
+}
+
+/** The Fatigue Index dial — the shipped 1–9 ramp, drawn exactly.
+ *  Not an app screenshot: a brand instrument rendering the real scale.
+ *  Hexes are the app's DARK-ground ramp tokens (index.css --fi-* dark set) —
+ *  the dial sits on navy, and the light-set red reads under 3:1 there.
+ *  The figcaption is the text alternative; the drawing itself is aria-hidden
+ *  so screen readers hear the reading once, not twice. */
+function FiDial() {
+  return (
+    <figure className="mx-auto max-w-[340px]">
+      <svg viewBox="0 0 200 200" aria-hidden="true">
+        <g fill="none">
+          <circle cx="100" cy="100" r="30" stroke="#38BDF8" strokeWidth="2.5" opacity="0.85" />
+          <circle cx="100" cy="100" r="37" stroke="#38BDF8" strokeWidth="2.5" opacity="0.85" />
+          <circle cx="100" cy="100" r="44" stroke="#38BDF8" strokeWidth="2.5" opacity="0.85" />
+          <circle cx="100" cy="100" r="51" stroke="#34D399" strokeWidth="3" opacity="0.9" />
+          <circle cx="100" cy="100" r="58" stroke="#34D399" strokeWidth="3" opacity="0.9" />
+          <circle cx="100" cy="100" r="65" stroke="#34D399" strokeWidth="3" opacity="0.9" />
+          <circle cx="100" cy="100" r="72" stroke="#FBBF24" strokeWidth="4" />
+          <circle cx="100" cy="100" r="79" stroke="#FBBF24" strokeWidth="4" />
+          <circle cx="100" cy="100" r="88" stroke="#F07668" strokeWidth="5" />
+          <line x1="100" y1="100" x2="100" y2="12" stroke="#F0EEEB" strokeOpacity="0.3" strokeWidth="1" />
+        </g>
+        <text
+          x="100"
+          y="100"
+          textAnchor="middle"
+          dominantBaseline="central"
+          fill="#F0EEEB"
+          fontSize="42"
+          fontWeight="700"
+          style={{ fontVariantNumeric: 'tabular-nums' }}
+        >
+          7
+        </text>
+      </svg>
+      <figcaption className="mt-4 text-[13px] text-sky-200 text-center">
+        The Fatigue Index. Every day scored, one to nine — seven is a day
+        you&rsquo;ll feel.
+      </figcaption>
+    </figure>
+  );
 }
 
 export function HomePage() {
-  const navigate = useNavigate();
-  const [showScrollIndicator, setShowScrollIndicator] = useState(true);
-
-  useEffect(() => {
-    const handleScroll = () => setShowScrollIndicator(window.scrollY < 100);
-    window.addEventListener('scroll', handleScroll);
-    return () => window.removeEventListener('scroll', handleScroll);
-  }, []);
-
-  const features: Feature[] = [
-    {
-      icon: Sparkles,
-      title: 'AI-Powered Planning',
-      desc: 'Smart recommendations tailored to your travel style and preferences',
-      color: 'from-mauve-500 to-mauve-600',
-    },
-    {
-      icon: TrendingUp,
-      title: 'Fatigue Index™',
-      desc: 'Proprietary system that optimizes your itinerary for energy and enjoyment',
-      color: 'from-emerald-500 to-teal-600',
-    },
-    {
-      icon: CreditCard,
-      title: 'Smart Budgeting',
-      desc: 'Real-time expense tracking with bank sync and receipt scanning',
-      color: 'from-amber-600 to-amber-700',
-    },
-    {
-      icon: Users,
-      title: 'Group Travel',
-      desc: 'Coordinate plans and split expenses effortlessly with travel companions',
-      color: 'from-sky-500 to-blue-600',
-    },
-    {
-      icon: Camera,
-      title: 'Trip Journal',
-      desc: 'Capture memories with location-verified photos and AI captions',
-      color: 'from-coral-500 to-coral-600',
-    },
-    {
-      icon: MessageCircle,
-      title: '24/7 AI Concierge',
-      desc: 'Get instant help with your plans, translations, and local tips',
-      color: 'from-sky-600 to-sky-700',
-    },
-  ];
-
-  const stats: Stat[] = [
-    { value: '50K+', label: 'Happy Travelers' },
-    { value: '120+', label: 'Countries' },
-    { value: '4.9', label: 'App Rating' },
-    { value: '24/7', label: 'AI Support' },
-  ];
-
   return (
-    <div className="overflow-hidden">
-      {/* Hero Section */}
-      <section className="relative min-h-screen flex items-center">
-        <div className="absolute inset-0">
-          <div className="absolute inset-0 bg-gradient-to-br from-slate-900 via-indigo-950 to-slate-900" />
-          <div
-            className="absolute inset-0 opacity-30"
-            style={{
-              backgroundImage:
-                'url("data:image/svg+xml,%3Csvg width="60" height="60" viewBox="0 0 60 60" xmlns="http://www.w3.org/2000/svg"%3E%3Cg fill="none" fill-rule="evenodd"%3E%3Cg fill="%239C92AC" fill-opacity="0.15"%3E%3Cpath d="M36 34v-4h-2v4h-4v2h4v4h2v-4h4v-2h-4zm0-30V0h-2v4h-4v2h4v4h2V6h4V4h-4zM6 34v-4H4v4H0v2h4v4h2v-4h4v-2H6zM6 4V0H4v4H0v2h4v4h2V6h4V4H6z"/%3E%3C/g%3E%3C/g%3E%3C/svg%3E")',
-            }}
-          />
-          <div className="absolute top-1/4 -left-32 w-96 h-96 bg-sky-500/20 rounded-full blur-3xl" />
-          <div className="absolute bottom-1/4 -right-32 w-96 h-96 bg-indigo-500/20 rounded-full blur-3xl" />
-        </div>
-
-        <div className="relative max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-32">
-          <div className="text-center">
-            <div className="inline-flex items-center px-4 py-2 bg-white/10 backdrop-blur-sm rounded-full mb-8 border border-white/20">
-              <Sparkles className="w-4 h-4 text-amber-400 mr-2" />
-              <span className="text-white/90 text-sm font-medium">
-                Introducing Fatigue Index™ Technology
-              </span>
-            </div>
-
-            <h1 className="text-5xl md:text-7xl font-bold text-white mb-6 leading-tight">
-              Travel Smarter,<br />
-              <span className="text-sky-300">
-                Not Harder
-              </span>
-            </h1>
-
-            <p className="text-xl md:text-2xl text-white/70 max-w-3xl mx-auto mb-10 leading-relaxed">
-              Your AI travel assistant that plans perfect itineraries, tracks budgets, and keeps you
-              energized throughout your journey.
-            </p>
-
-            <div className="flex flex-col sm:flex-row gap-4 justify-center mb-16">
-              <button
-                type="button"
-                onClick={() => navigate('/contact')}
-                className="group px-8 py-4 bg-amber-400 text-gray-900 rounded-full font-semibold text-lg shadow-xl shadow-amber-400/25 hover:shadow-2xl hover:shadow-amber-400/30 transition-all"
+    <div>
+      {/* 01 — The number. Flat Ateneo, no photograph: the scale is the image. */}
+      <section className="relative overflow-hidden bg-sky-600">
+        <ContourArcs className="absolute -top-44 -left-44 w-[520px] h-[520px]" />
+        <ContourArcs className="absolute -bottom-56 -right-40 w-[520px] h-[520px]" />
+        <div className="relative max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 pt-32 pb-20 md:pt-40 md:pb-28">
+          <div className="grid lg:grid-cols-12 gap-12 lg:gap-8 items-center">
+            <div className="lg:col-span-7">
+              <p className="text-[11px] font-semibold tracking-[0.14em] uppercase text-amber-400 mb-6 [font-variant-numeric:tabular-nums]">
+                01 — The Fatigue Index
+              </p>
+              <h1 className="text-4xl md:text-5xl font-bold text-gray-50 leading-tight [text-wrap:balance] mb-6">
+                Nine is a hard day.
+              </h1>
+              <p className="text-lg md:text-xl text-sky-100 leading-relaxed max-w-xl mb-4">
+                JarvisTravel scores every day of a trip from one to nine. It
+                reads how far your body clock will move, how long you&rsquo;ll be
+                in transit, how far you&rsquo;ll walk, how densely the day is
+                packed, and how much downtime it leaves you. One is easy. Nine
+                you will feel.
+              </p>
+              <p className="text-sm text-sky-200 mb-10">
+                Planning only. We take no commissions, and we&rsquo;re not a
+                seller of travel.
+              </p>
+              {/* Routes to the interest form until the app/payment flow is live. */}
+              <Link
+                to="/contact"
+                className="inline-block px-8 py-4 bg-amber-400 text-gray-900 rounded-full font-semibold hover:bg-amber-300 transition-colors"
               >
                 Sign up
-              </button>
+              </Link>
             </div>
-
-            <div className="grid grid-cols-2 md:grid-cols-4 gap-8 max-w-3xl mx-auto">
-              {stats.map((stat, i) => (
-                <div key={i} className="text-center">
-                  <div className="text-3xl md:text-4xl font-bold text-white mb-1">
-                    {stat.value}
-                  </div>
-                  <div className="text-white/50 text-sm">{stat.label}</div>
-                </div>
-              ))}
+            <div className="lg:col-span-5">
+              <FiDial />
             </div>
-          </div>
-        </div>
-
-        <div
-          className={`absolute bottom-8 left-1/2 -translate-x-1/2 transition-opacity duration-500 ${
-            showScrollIndicator ? 'opacity-100' : 'opacity-0'
-          }`}
-        >
-          <div className="animate-bounce">
-            <ChevronDown className="w-8 h-8 text-white/50" />
           </div>
         </div>
       </section>
 
-      {/* Features Grid */}
-      <section className="py-24 bg-white">
-        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-          <div className="text-center mb-16">
-            <h2 className="text-4xl md:text-5xl font-bold text-gray-900 mb-4">
-              Everything You Need to Travel Better
-            </h2>
-            <p className="text-xl text-gray-600 max-w-2xl mx-auto">
-              Powerful features designed to make every trip unforgettable
-            </p>
-          </div>
+      {/* 02 — The belief. Tight, no image, no CTA: a belief with a button
+          attached stops being a belief. */}
+      <section className="bg-gray-50">
+        <div className="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8 py-16 md:py-20">
+          <p className="text-[11px] font-semibold tracking-[0.14em] uppercase text-amber-700 mb-6 [font-variant-numeric:tabular-nums]">
+            02 — Why it works this way
+          </p>
+          <h2 className="text-3xl md:text-4xl font-bold text-gray-900 [text-wrap:balance] mb-6">
+            We started from the end of the day.
+          </h2>
+          <p className="text-lg text-gray-600 leading-relaxed">
+            Twelve tabs, a shared spreadsheet and a map full of pins will get
+            you a plan. What none of them will tell you is whether Thursday is
+            survivable. So we built the pacing model first and hung the
+            itinerary off it — because the failure everyone recognizes is not a
+            museum you missed. It&rsquo;s standing somewhere you spent a year
+            wanting to be, too tired to want it.
+          </p>
+        </div>
+      </section>
 
-          <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-8">
-            {features.map((feature, i) => {
-              const IconComponent = feature.icon;
+      {/* 03 — How the number is made. The dial's chapter carries no CTA. */}
+      <section className="relative overflow-hidden bg-sky-600">
+        <ContourArcs className="absolute -top-52 -right-44 w-[520px] h-[520px]" />
+        <div className="relative max-w-3xl mx-auto px-4 sm:px-6 lg:px-8 py-20 md:py-24">
+          <p className="text-[11px] font-semibold tracking-[0.14em] uppercase text-amber-400 mb-6 [font-variant-numeric:tabular-nums]">
+            03 — How the number is made
+          </p>
+          <h2 className="text-3xl md:text-4xl font-bold text-gray-50 [text-wrap:balance] mb-6">
+            Where the number comes from.
+          </h2>
+          <p className="text-lg text-sky-100 leading-relaxed mb-10">
+            Five inputs, weighted. Out comes one number, one to nine. At seven
+            and above, Jarvis flags the day before you commit and offers a
+            lighter version of the same day.
+          </p>
+          <ul className="border-t border-white/15">
+            {FI_INPUTS.map((input) => (
+              <li
+                key={input.name}
+                className="grid sm:grid-cols-[180px_1fr] gap-1 sm:gap-6 py-4 border-b border-white/15"
+              >
+                <span className="font-medium text-gray-50">{input.name}</span>
+                <span className="text-sky-200">{input.desc}</span>
+              </li>
+            ))}
+          </ul>
+          <p className="mt-8 text-sm text-sky-200">
+            It describes what the day costs, not what it cures — a pacing
+            model, not medical advice.
+          </p>
+        </div>
+      </section>
+
+      {/* 04 — Restraints. The honest replacement for the old stat bar. */}
+      <section className="bg-gray-50">
+        <div className="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8 py-20 md:py-24">
+          <p className="text-[11px] font-semibold tracking-[0.14em] uppercase text-amber-700 mb-6 [font-variant-numeric:tabular-nums]">
+            04 — Restraints
+          </p>
+          <h2 className="text-3xl md:text-4xl font-bold text-gray-900 [text-wrap:balance] mb-10">
+            Three things it will never do.
+          </h2>
+          <ul className="border-t border-gray-200">
+            {RESTRAINTS.map((item) => (
+              <li key={item.name} className="py-6 border-b border-gray-200">
+                <h3 className="text-xl font-semibold text-gray-900 mb-2">{item.name}</h3>
+                <p className="text-gray-600 leading-relaxed">{item.desc}</p>
+              </li>
+            ))}
+          </ul>
+          {/* Routes to the interest form until the app/payment flow is live. */}
+          <Link
+            to="/contact"
+            className="inline-block mt-10 px-8 py-4 bg-amber-400 text-gray-900 rounded-full font-semibold hover:bg-amber-300 transition-colors"
+          >
+            Sign up
+          </Link>
+        </div>
+      </section>
+
+      {/* 05 — What's in the product. Shipped features only; the app's icon
+          row recipe (tinted voice container, glyph in the voice color). */}
+      <section className="bg-white">
+        <div className="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8 py-20 md:py-24">
+          <p className="text-[11px] font-semibold tracking-[0.14em] uppercase text-amber-700 mb-6 [font-variant-numeric:tabular-nums]">
+            05 — What&rsquo;s in the product
+          </p>
+          <h2 className="text-3xl md:text-4xl font-bold text-gray-900 [text-wrap:balance] mb-10">
+            What Jarvis does today.
+          </h2>
+          <ul className="border-t border-gray-200">
+            {PRODUCT_ROWS.map((row) => {
+              const Icon = row.icon;
               return (
-                <div
-                  key={i}
-                  className="group p-8 rounded-3xl bg-gray-50 hover:bg-white hover:shadow-xl transition-all duration-300 border border-transparent hover:border-gray-100"
-                >
-                  <div
-                    className={`w-14 h-14 rounded-2xl bg-gradient-to-br ${feature.color} flex items-center justify-center mb-6 shadow-lg group-hover:scale-110 transition-transform`}
+                <li key={row.name} className="flex items-start gap-4 py-5 border-b border-gray-200">
+                  <span
+                    className={`w-9 h-9 rounded-lg flex items-center justify-center flex-shrink-0 ${
+                      row.voice === 'journal'
+                        ? 'bg-coral-600/10 text-coral-600'
+                        : 'bg-sky-600/10 text-sky-600'
+                    }`}
                   >
-                    <IconComponent className="w-7 h-7 text-white" />
+                    <Icon className="w-5 h-5" strokeWidth={2} aria-hidden="true" />
+                  </span>
+                  <div>
+                    <h3 className="font-semibold text-gray-900">{row.name}</h3>
+                    <p className="text-gray-600">{row.desc}</p>
                   </div>
-                  <h3 className="text-xl font-semibold text-gray-900 mb-3">{feature.title}</h3>
-                  <p className="text-gray-600 leading-relaxed">{feature.desc}</p>
-                </div>
+                </li>
               );
             })}
-          </div>
+          </ul>
         </div>
       </section>
 
-      {/* Fatigue Index Feature */}
-      <section className="py-24 bg-gradient-to-br from-indigo-950 via-slate-900 to-indigo-950 text-white overflow-hidden relative">
-        <div className="absolute top-0 right-0 w-1/2 h-full bg-gradient-to-l from-sky-500/10 to-transparent" />
-        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 relative">
-          <div className="grid lg:grid-cols-2 gap-16 items-center">
-            <div>
-              <div className="inline-flex items-center px-4 py-2 bg-emerald-500/20 rounded-full mb-6 border border-emerald-500/30">
-                <Award className="w-4 h-4 text-emerald-400 mr-2" />
-                <span className="text-emerald-300 text-sm font-medium">Patent Pending Technology</span>
-              </div>
-              <h2 className="text-4xl md:text-5xl font-bold mb-6">
-                Introducing the<br />
-                <span className="text-emerald-400">Fatigue Index™</span>
-              </h2>
-              <p className="text-xl text-white/70 mb-8 leading-relaxed">
-                Our proprietary algorithm analyzes jet lag, sleep patterns, activity intensity, and
-                travel time to optimize your itinerary for maximum enjoyment and minimum exhaustion.
-              </p>
-              <ul className="space-y-4 mb-8">
-                {[
-                  'Personalized energy predictions',
-                  'Smart activity scheduling',
-                  'Recovery time recommendations',
-                  'Real-time adjustments',
-                ].map((item, i) => (
-                  <li key={i} className="flex items-center text-white/80">
-                    <CheckCircle className="w-5 h-5 text-emerald-400 mr-3 flex-shrink-0" />
-                    {item}
-                  </li>
-                ))}
-              </ul>
-              <button
-                type="button"
-                onClick={() => navigate('/features')}
-                className="px-6 py-3 bg-emerald-500 text-white rounded-full font-medium hover:bg-emerald-600 transition-all"
-              >
-                Learn More About FI™
-              </button>
-            </div>
-            <div className="bg-white/5 backdrop-blur-sm rounded-3xl p-8 border border-white/10">
-              <div className="text-center mb-6">
-                <div className="text-6xl font-bold text-emerald-400 mb-2">72</div>
-                <div className="text-white/60">Current Fatigue Index</div>
-              </div>
-              <div className="h-4 bg-white/10 rounded-full overflow-hidden mb-6">
-                <div className="h-full w-3/4 bg-gradient-to-r from-emerald-500 to-emerald-400 rounded-full" />
-              </div>
-              <div className="grid grid-cols-3 gap-4 text-center">
-                {[
-                  { label: 'Jet Lag', value: '+8' },
-                  { label: 'Sleep Debt', value: '2h' },
-                  { label: 'Activity', value: 'Med' },
-                ].map((item, i) => (
-                  <div key={i} className="bg-white/5 rounded-xl p-3">
-                    <div className="text-lg font-semibold text-white">{item.value}</div>
-                    <div className="text-xs text-white/50">{item.label}</div>
-                  </div>
-                ))}
-              </div>
-            </div>
-          </div>
-        </div>
-      </section>
-
-      {/* Testimonials removed (JAR-429): the previous roster was fabricated,
-          and early-access quotes are held back by brand-owner decision so no
-          published review needs a material-connection disclosure. Reintroduce
-          only post-launch, from arm's-length users. */}
-
-      {/* CTA Section */}
-      <section className="py-24 bg-gradient-to-r from-sky-600 to-indigo-600 text-white">
-        <div className="max-w-4xl mx-auto text-center px-4">
-          <h2 className="text-4xl md:text-5xl font-bold mb-6">Ready to Travel Smarter?</h2>
-          <p className="text-xl text-white/80 mb-10">
+      {/* The invitation — deliberately unnumbered: it is not a chapter, and
+          ending the count on nine (our own definition of a hard day) would
+          teach the wrong thing. The only centered section on the page. */}
+      <section className="relative overflow-hidden bg-slate-900">
+        <ContourArcs className="absolute -top-40 -left-48 w-[520px] h-[520px]" />
+        <ContourArcs className="absolute -bottom-52 -right-44 w-[520px] h-[520px]" />
+        <div className="relative max-w-2xl mx-auto px-4 sm:px-6 lg:px-8 py-20 md:py-28 text-center">
+          <p className="text-[11px] font-semibold tracking-[0.14em] uppercase text-amber-400 mb-6">
+            Early access
+          </p>
+          <h2 className="text-3xl md:text-4xl font-bold text-gray-50 [text-wrap:balance] mb-4">
+            Come plan something slow.
+          </h2>
+          <p className="text-lg text-sky-100 mb-10">
             Sign up to be the first to know when we launch.
           </p>
           {/* Routes to the interest form until the app/payment flow is live. */}
-          <button
-            type="button"
-            onClick={() => navigate('/contact')}
-            className="px-10 py-5 bg-white text-indigo-600 rounded-full font-semibold text-lg hover:shadow-2xl transition-all"
+          <Link
+            to="/contact"
+            className="inline-block px-10 py-4 bg-amber-400 text-gray-900 rounded-full font-semibold hover:bg-amber-300 transition-colors"
           >
             Sign up
-          </button>
+          </Link>
         </div>
       </section>
     </div>

--- a/src/app/pages/HomePage.tsx
+++ b/src/app/pages/HomePage.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import {
   BookOpen,
   CloudSun,
@@ -9,13 +10,43 @@ import {
 import { Link } from 'react-router-dom';
 import type { LucideIcon } from 'lucide-react';
 
-// Home (JAR-431, reworked per brand-owner direction 2026-07-21): this page
-// tells the story — what a traveler misses without JarvisTravel and what
-// planning wrong costs — in benefit language. The Fatigue Index deep-dive
-// (mechanics, inputs, the dial) lives on /features; here FI appears only as
-// a benefit, always written with numeric digits (1–9, 7), never spelled out.
-// The numbered section eyebrows were retired sitewide: they read like slides.
-// Every factual claim still maps to shipped code.
+// Home (JAR-431). Benefit-led story per the jarvistravel-copy voice skill:
+// what a traveler misses without JarvisTravel and what planning wrong costs.
+// The Fatigue Index deep-dive lives on /features; FI appears here only as a
+// benefit, always in digits (1 to 9). No em dashes anywhere (brand rule).
+//
+// The hero rotates: one of five approved headline pairs is picked per visit,
+// so two visitors may see different messaging (lightweight A/B signal).
+// The pick is client-side; if prerendering lands (plan phase 3), move the
+// pick to a post-hydration effect to avoid a server/client mismatch.
+
+interface Hero {
+  headline: string;
+  sub: string;
+}
+
+const HEROES: Hero[] = [
+  {
+    headline: 'Your vacation should be a break, not a second job.',
+    sub: 'JarvisTravel plans the pace, the budget and the map in one place, so the trip you take feels like the trip you imagined.',
+  },
+  {
+    headline: 'Travel smarter, not harder.',
+    sub: 'One plan for the days, the money and the memories. Jarvis does the homework; you take the trip.',
+  },
+  {
+    headline: 'Enjoy your vacation.',
+    sub: 'Planning is hard. Jarvis does the heavy lifting: the pace, the budget, the map, all in one place.',
+  },
+  {
+    headline: 'Come home with stories, not exhaustion.',
+    sub: 'Jarvis rates every day of your plan 1 to 9, so the hard days show up before you do.',
+  },
+  {
+    headline: 'Twelve tabs is not a travel plan.',
+    sub: 'The days, the budget, the map and the journal, together in one place that thinks about pacing.',
+  },
+];
 
 interface Feature {
   icon: LucideIcon;
@@ -25,8 +56,7 @@ interface Feature {
 }
 
 // Shipped features only, written as benefits. Icons follow the app's row
-// recipe — tinted voice containers, glyph in the voice color; coral belongs
-// to the journal and appears nowhere else.
+// recipe. Coral belongs to the journal and appears nowhere else.
 const FEATURES: Feature[] = [
   {
     icon: Sparkles,
@@ -37,19 +67,19 @@ const FEATURES: Feature[] = [
   {
     icon: TrendingUp,
     name: 'The Fatigue Index',
-    desc: 'Every day rated 1–9 before you commit, so the hard days show up while you can still fix them.',
+    desc: 'Every day rated 1 to 9 before you commit, so the hard days show up while you can still fix them.',
     voice: 'accent',
   },
   {
     icon: Wallet,
     name: 'Budget',
-    desc: 'Totals that move while you plan — not a surprise after you land back home.',
+    desc: 'Totals that move while you plan, not a surprise after you land back home.',
     voice: 'accent',
   },
   {
     icon: BookOpen,
     name: 'Trip journal',
-    desc: 'Notes, photos, receipts and places become a story worth rereading — yours to keep.',
+    desc: 'Notes, photos, receipts and places become a story worth rereading. Yours to keep.',
     voice: 'journal',
   },
   {
@@ -61,12 +91,12 @@ const FEATURES: Feature[] = [
   {
     icon: CloudSun,
     name: 'Weather & flights',
-    desc: 'The forecast and your flights sit inside the plan — fewer surprises, fewer tabs.',
+    desc: 'The forecast and your flights sit inside the plan. Fewer surprises, fewer tabs.',
     voice: 'accent',
   },
 ];
 
-/** Concentric contour rings — the Meridian motif, Moonlight at 13% on navy.
+/** Concentric contour rings, the Meridian motif: Moonlight at 13% on navy.
  *  pointer-events-none so the overlay can never intercept clicks on content. */
 function ContourArcs({ className }: { className: string }) {
   return (
@@ -92,19 +122,23 @@ function ContourArcs({ className }: { className: string }) {
 }
 
 export function HomePage() {
+  // Picked once per mount so the message is stable while the visitor reads.
+  const [hero] = useState<Hero>(
+    () => HEROES[Math.floor(Math.random() * HEROES.length)]
+  );
+
   return (
     <div>
-      {/* Hero — the story, not the mechanics. */}
+      {/* Hero: the story, not the mechanics. */}
       <section className="relative overflow-hidden bg-sky-600">
         <ContourArcs className="absolute -top-44 -left-44 w-[520px] h-[520px]" />
         <ContourArcs className="absolute -bottom-56 -right-40 w-[520px] h-[520px]" />
         <div className="relative max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 pt-36 pb-24 md:pt-44 md:pb-32 text-center">
           <h1 className="text-4xl md:text-5xl font-bold text-gray-50 leading-tight [text-wrap:balance] mb-6">
-            Your vacation should be a break, not a second job.
+            {hero.headline}
           </h1>
           <p className="text-lg md:text-xl text-sky-100 leading-relaxed max-w-2xl mx-auto mb-10">
-            JarvisTravel plans the pace, the budget and the map in one place —
-            so the trip you take feels like the trip you imagined.
+            {hero.sub}
           </p>
           {/* Routes to the interest form until the app/payment flow is live. */}
           <Link
@@ -116,7 +150,7 @@ export function HomePage() {
         </div>
       </section>
 
-      {/* The cost of planning wrong — what you miss without it. */}
+      {/* The cost of planning wrong: what you miss without it. */}
       <section className="bg-gray-50">
         <div className="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8 py-16 md:py-20">
           <h2 className="text-3xl md:text-4xl font-bold text-gray-900 [text-wrap:balance] mb-6">
@@ -124,8 +158,8 @@ export function HomePage() {
             Tuesday.
           </h2>
           <p className="text-lg text-gray-600 leading-relaxed mb-6">
-            Twelve tabs and a shared spreadsheet will get you a plan — but they
-            won&rsquo;t tell you that day 2 has six hours of walking after a
+            Twelve tabs and a shared spreadsheet will get you a plan. What they
+            won&rsquo;t tell you is that day 2 has six hours of walking after a
             red-eye, or that the museum, the market and the dinner across town
             don&rsquo;t fit in the same afternoon. That&rsquo;s the trip where
             you come home needing a vacation from the vacation.
@@ -133,8 +167,8 @@ export function HomePage() {
           <p className="text-lg text-gray-600 leading-relaxed mb-8">
             Jarvis rates every day of your plan from 1 to 9 while you build it.
             When a day hits 7, you&rsquo;ll know before you&rsquo;re standing in
-            it — and Jarvis offers a lighter version of the same day, so fixing
-            it takes one tap instead of a family argument.
+            it, and Jarvis offers a lighter version of the same day. Fixing it
+            takes one tap instead of a family argument.
           </p>
           <Link
             to="/features"
@@ -145,7 +179,7 @@ export function HomePage() {
         </div>
       </section>
 
-      {/* What you get — the product, in benefit language. */}
+      {/* What you get: the product, in benefit language. */}
       <section className="bg-white">
         <div className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 py-16 md:py-20">
           <div className="max-w-2xl mb-12">
@@ -153,8 +187,8 @@ export function HomePage() {
               One plan, instead of twelve tabs.
             </h2>
             <p className="text-lg text-gray-600 leading-relaxed">
-              Everything that makes a trip work — and everything you&rsquo;d
-              rather not juggle — in one place.
+              Everything that makes a trip work, and everything you&rsquo;d
+              rather not juggle, in one place.
             </p>
           </div>
           <div className="grid sm:grid-cols-2 lg:grid-cols-3 gap-6">
@@ -183,8 +217,7 @@ export function HomePage() {
         </div>
       </section>
 
-      {/* Why you can trust the plan — three promises, in plain speak
-          (voice per the jarvistravel-copy skill). */}
+      {/* Why you can trust the plan: three promises, in plain speak. */}
       <section className="bg-gray-50">
         <div className="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8 py-16 md:py-20">
           <h2 className="text-3xl md:text-4xl font-bold text-gray-900 [text-wrap:balance] mb-10">
@@ -196,7 +229,7 @@ export function HomePage() {
                 Nobody pays to be in your plan.
               </h3>
               <p className="text-gray-600 leading-relaxed">
-                Every suggestion is there because it fits your trip — never
+                Every suggestion is there because it fits your trip, never
                 because a hotel or tour paid us.
               </p>
             </li>
@@ -213,7 +246,7 @@ export function HomePage() {
                 Your memories belong to you.
               </h3>
               <p className="text-gray-600 leading-relaxed">
-                Your journal — the notes, the photos, the places — is yours. We
+                Your journal is yours: the notes, the photos, the places. We
                 never sell it.
               </p>
             </li>
@@ -230,7 +263,7 @@ export function HomePage() {
             Enjoy your vacation.
           </h2>
           <p className="text-lg text-sky-100 mb-10">
-            Planning is hard. Jarvis does the heavy lifting — sign up and be
+            Planning is hard. Jarvis does the heavy lifting. Sign up and be
             first in when we launch.
           </p>
           {/* Routes to the interest form until the app/payment flow is live. */}

--- a/src/app/pages/HomePage.tsx
+++ b/src/app/pages/HomePage.tsx
@@ -50,6 +50,13 @@ const HEROES: Hero[] = [
   },
 ];
 
+// Photography slot for the "Not just the big trip" band. Set this to a real
+// golden-hour, people-in-place frame (self-hosted in public/) once a shoot or
+// licensed image lands - see the photography sourcing decision. Leaving it
+// null renders the designed navy-and-motif fallback, so the site never ships
+// an empty frame or off-brand stock.
+const BREADTH_PHOTO: { src: string; alt: string } | null = null;
+
 interface Feature {
   icon: LucideIcon;
   name: string;
@@ -182,13 +189,33 @@ export function HomePage() {
         </div>
       </section>
 
-      {/* Every trip counts: the app is not just for the one big trip a year. */}
-      <section className="bg-white">
-        <div className="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8 pt-16 md:pt-20">
-          <h2 className="text-3xl md:text-4xl font-bold text-gray-900 [text-wrap:balance] mb-6">
+      {/* Every trip counts, as a full-bleed editorial band. Photo-ready: drop
+          a golden-hour frame into BREADTH_PHOTO and it renders full-bleed
+          under the ratified Neverything scrim. Until then the band stands on
+          its own as the designed navy-and-motif fallback. */}
+      <section className="relative overflow-hidden bg-sky-600 min-h-[46vh] flex items-center">
+        {BREADTH_PHOTO && (
+          <>
+            <img
+              src={BREADTH_PHOTO.src}
+              alt={BREADTH_PHOTO.alt}
+              className="absolute inset-0 w-full h-full object-cover"
+            />
+            {/* The one ratified gradient: single-hue Neverything scrim. */}
+            <div className="absolute inset-0 bg-gradient-to-t from-[#13181B]/85 via-[#13181B]/45 to-[#13181B]/35" />
+          </>
+        )}
+        {!BREADTH_PHOTO && (
+          <>
+            <ContourArcs className="absolute -top-40 -left-40 w-[520px] h-[520px]" />
+            <ContourArcs className="absolute -bottom-52 -right-36 w-[520px] h-[520px]" />
+          </>
+        )}
+        <div className="relative max-w-3xl mx-auto px-4 sm:px-6 lg:px-8 py-16 md:py-20">
+          <h2 className="text-3xl md:text-4xl font-bold text-gray-50 [text-wrap:balance] mb-6">
             Not just the big trip.
           </h2>
-          <p className="text-lg text-gray-600 leading-relaxed">
+          <p className="text-lg md:text-xl text-sky-100 leading-relaxed max-w-2xl">
             A long weekend, a staycation, two weeks abroad, a road trip an hour
             from home. Jarvis plans them all: the pace, the budget, the map, the
             memories.

--- a/src/app/pages/HomePage.tsx
+++ b/src/app/pages/HomePage.tsx
@@ -190,8 +190,8 @@ export function HomePage() {
           </h2>
           <p className="text-lg text-gray-600 leading-relaxed">
             A long weekend, a staycation, two weeks abroad, a road trip an hour
-            from home. If it has days, Jarvis plans them: the pace, the budget,
-            the map, the memories.
+            from home. Jarvis plans them all: the pace, the budget, the map, the
+            memories.
           </p>
         </div>
       </section>

--- a/src/app/pages/HomePage.tsx
+++ b/src/app/pages/HomePage.tsx
@@ -266,8 +266,7 @@ export function HomePage() {
             Enjoy your vacation.
           </h2>
           <p className="text-lg text-sky-100 mb-10">
-            Planning is hard. Jarvis does the heavy lifting. Sign up and be
-            the first to know when we launch.
+            Planning is hard. Jarvis does the heavy lifting.
           </p>
           {/* Routes to the interest form until the app/payment flow is live. */}
           <Link

--- a/src/app/utils/imagery.ts
+++ b/src/app/utils/imagery.ts
@@ -1,0 +1,86 @@
+import { useEffect, useState } from 'react';
+
+// Photography, ported from the JarvisTravel app's integration so the two
+// properties source imagery the same way. Destination/section photos come from
+// the Pexels API (free). When VITE_PEXELS_API_KEY is not set, lookups return
+// null and callers fall back to a provided image (or the designed navy band),
+// so the site never ships an empty frame or a broken request.
+
+const PEXELS_KEY = import.meta.env.VITE_PEXELS_API_KEY as string | undefined;
+const MAX_CACHE = 50;
+const cache = new Map<string, string>();
+
+function cacheSet(key: string, value: string) {
+  if (cache.size >= MAX_CACHE) {
+    const oldest = cache.keys().next().value;
+    if (oldest !== undefined) cache.delete(oldest);
+  }
+  cache.set(key, value);
+}
+
+export async function fetchImage(query: string): Promise<string | null> {
+  const q = query.trim();
+  if (!PEXELS_KEY || !q) return null;
+  if (cache.has(q)) return cache.get(q)!;
+  try {
+    const res = await fetch(
+      `https://api.pexels.com/v1/search?query=${encodeURIComponent(q)}&per_page=1&orientation=landscape`,
+      { headers: { Authorization: PEXELS_KEY } },
+    );
+    if (!res.ok) return null;
+    const data = await res.json();
+    const url: string | undefined =
+      data?.photos?.[0]?.src?.landscape ?? data?.photos?.[0]?.src?.large;
+    if (url) cacheSet(q, url);
+    return url ?? null;
+  } catch {
+    return null;
+  }
+}
+
+/** Returns the fallback until a Pexels photo loads, then the photo. */
+export function useImage(query: string, fallback?: string): string | undefined {
+  const [url, setUrl] = useState<string | undefined>(undefined);
+  useEffect(() => {
+    let cancelled = false;
+    fetchImage(query).then((u) => {
+      if (!cancelled && u) setUrl(u);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [query]);
+  return url ?? fallback;
+}
+
+// Both CDNs serve any width via ?w=, so we build a srcSet and let the browser
+// pull the right resolution. Non-CDN URLs return undefined (plain src is used).
+const CDN_HOSTS = ['images.unsplash.com', 'images.pexels.com'] as const;
+const DEFAULT_WIDTHS = [768, 1080, 1440, 2000];
+
+function isCdnImage(url: string): boolean {
+  try {
+    return (CDN_HOSTS as readonly string[]).includes(new URL(url).hostname);
+  } catch {
+    return false;
+  }
+}
+
+function atWidth(url: string, w: number): string {
+  try {
+    const u = new URL(url);
+    u.searchParams.set('w', String(w));
+    if (u.hostname === 'images.unsplash.com') {
+      u.searchParams.set('q', '80');
+      u.searchParams.set('auto', 'format');
+    }
+    return u.toString();
+  } catch {
+    return url;
+  }
+}
+
+export function imageSrcSet(url?: string, widths: number[] = DEFAULT_WIDTHS): string | undefined {
+  if (!url || !isCdnImage(url)) return undefined;
+  return widths.map((w) => `${atWidth(url, w)} ${w}w`).join(', ');
+}

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,0 +1,11 @@
+/// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  /** Pexels API key for section/hero photography. Optional; when unset,
+   *  photo lookups return nothing and bands render their designed fallback. */
+  readonly VITE_PEXELS_API_KEY?: string;
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}


### PR DESCRIPTION
## What

The home page rebuilt on the NINE structure — the second redesign PR after #27 (pricing). Asset-light by design: no photography and no app captures exist yet, so the page rests on what is real — the shipped 1–9 Fatigue Index and honest copy.

**Deleted** (all audit findings): the fabricated stat bar (50K+/120+/4.9/24-7), the dark-gradient hero + blur orbs + noise SVG + backdrop-blur badge, the `min-h-screen` hero, the six gradient icon tiles wearing *data-palette* colors as chrome, the gradient CTA band, and every unbuilt-feature claim (bank sync, receipt scanning, group voting, "24/7", "sleep patterns" — `restPeriods` is not sleep debt).

**Built**: 01 hero ("Nine is a hard day.") with the FI dial; 02 belief band; 03 the five engine inputs as hairline rows; 04 three restraints; 05 shipped-features list in the app's icon language; unnumbered closing invitation. Section numerals 01–05 with tabular figures; contour-ring motif on navy only; one solid amber CTA per section; "Sign up" CTAs routing to the interest form until the app/payment flow is live.

## The dial replaces the fabricated dashboard

The old page illustrated the flagship differentiator with an invented UI showing **72 on an implied 0–100 scale** — the shipped engine returns **1–9**. The new hero draws the real scale: nine rings grouped 3/3/2/1 using the app's dark-ground FI ramp tokens verbatim (`--fi-*` dark set: `#38BDF8`/`#34D399`/`#FBBF24`/`#F07668`) — chosen over the light set because the dial sits on navy, where the light-set red reads 2.8:1 (below the 3:1 non-text minimum); the dark set reads ≥4.1:1 on every ring.

## Every claim verified against origin/main

A 3-agent adversarial panel (truthfulness vs the web-app on `origin/main` / brand rules / a11y) reviewed the draft — **no blockers**; all should-fixes applied before this PR:

- The five inputs map 1:1 to `FATIGUE_WEIGHTS` (jetLag, travelTime, walkingDistance, activityDensity, restPeriods) with no invention.
- "At seven and above, Jarvis flags the day and offers a lighter version" — verified shipped (`score >= 7` gate + ScenarioCompare/lightenDay).
- All seven §05 feature rows correspond to shipped code; the map row softened to "Your trip on one map, numbered by day" (the overview clusters one marker per day).
- **"Never used to train anyone's model" held back**: the Privacy Policy is silent on training, and a published commitment must match the policy word for word. Restore alongside the legal-pages phase — recommended, it's a real differentiator.
- "We never touch your money" → "We take no commissions" (the Terms themselves say JarvisTravel charges subscription fees; payments will be processed by Stripe when live).
- Dial announced once to screen readers (figcaption is the text alternative), contour arcs `pointer-events-none`, `Map` import unshadowed.

## Merge order note

Expected conflict with PR #26, whose HomePage hunks are a **subset** of this rewrite. Preferred order: merge #26 first, then rebase this branch — the rewrite wins the conflict trivially. (If this merges first, drop the HomePage hunks from #26 on rebase; its Navigation/Footer/Features changes are untouched here.)

## Verification

`npm run lint` clean · `tsc --noEmit` clean · `check-plan-not-book` passes · `vite build` green. Visually verified desktop + 375px mobile: no horizontal overflow, all three CTAs receive clicks, heading order h1→h2→h3 clean, zero gradients/orbs/shadows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)