### PR TITLE
refactor(JAR-438): prune dead color families from Tailwind config

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -8,26 +8,29 @@ export default {
     extend: {
       colors: {
         // ── Meridian brand (guide v1.0) ──
-        // The site's working scales are remapped onto the palette: the old
-        // sky/indigo/blue/purple accents all resolve to the Ateneo family
-        // (gradient pairs become tonal blue, per the no-rainbow rule), the
-        // gray light end becomes Magical Moonlight with Neverything ink at
-        // the dark end, and amber is Sea Buckthorn — the CTA color, always
-        // with ink text. Stock shades not listed are unchanged.
+        // The site's working scales are remapped onto the palette: sky resolves
+        // to the Ateneo family (per the no-rainbow rule), the gray light end
+        // becomes Magical Moonlight with Neverything ink at the dark end, and
+        // amber is Sea Buckthorn — the CTA color, always with ink text. Stock
+        // shades not listed are unchanged.
+        // The old rainbow remaps (blue/indigo/purple) and the mauve data
+        // extension were dropped in JAR-438: the NINE redesign folded every
+        // rainbow accent into Ateneo, so none are referenced anywhere. A stray
+        // stock class like `bg-blue-600` should surface in review, not get
+        // silently recolored on-brand.
         sky: { 50: '#EDF4FA', 100: '#DBE9F4', 200: '#B7D3E9', 300: '#8CC0E8', 400: '#5E9DD1', 500: '#2E6FA3', 600: '#003A6C', 700: '#083258', 800: '#0B2B49', 900: '#0E2A47', 950: '#081E33' },
-        blue: { 50: '#EDF4FA', 100: '#DBE9F4', 200: '#B7D3E9', 300: '#8CC0E8', 400: '#4E8FC7', 500: '#2E6FA3', 600: '#003A6C', 700: '#083258', 800: '#0B2B49', 900: '#0E2A47', 950: '#081E33' },
-        indigo: { 50: '#EDF4FA', 100: '#DBE9F4', 200: '#B7D3E9', 300: '#8CC0E8', 400: '#4E8FC7', 500: '#14507F', 600: '#0B4678', 700: '#003A6C', 800: '#0B2B49', 900: '#0E2A47', 950: '#0A1F35' },
-        // purple intentionally mirrors the indigo ramp — both fold into Ateneo,
-        // so shared stops (e.g. .200/.300 with indigo) are deliberate, not typos.
-        purple: { 50: '#EDF4FA', 100: '#DBE9F4', 200: '#B7D3E9', 300: '#8CC0E8', 400: '#4E8FC7', 500: '#14507F', 600: '#0B4678', 700: '#003A6C', 800: '#0B2B49', 900: '#0E2A47', 950: '#0A1F35' },
         amber: { 300: '#FFCC85', 400: '#FFBF65', 500: '#F0A94D', 600: '#C98A2E', 700: '#9A5B00' },
         gray: { 50: '#F0EEEB', 100: '#E8E4DE', 200: '#DAD5CD', 300: '#C7C1B8', 400: '#8E9AA4', 500: '#5C6B77', 600: '#4A5560', 700: '#3A444C', 800: '#262E33', 900: '#13181B', 950: '#0C1013' },
         slate: { 900: '#0E2A47', 950: '#081E33' },
-        // Meridian data-set extensions (match the app's categorical colors):
-        // coral = the journal's family, mauve = the dusk stop of the palette.
+        // Meridian data-set extension (matches the app's categorical colors):
+        // coral is the journal's family.
         coral: { 400: '#FD8973', 500: '#C94F36', 600: '#B23F2C', 700: '#8F3223' },
-        mauve: { 400: '#A85D79', 500: '#8A5474', 600: '#6E4A62', 700: '#5A3C50' },
       },
+      // Tailwind's default ring color is colors.blue.500. With the blue remap
+      // removed (JAR-438) that default would revert to stock rainbow blue in the
+      // compiled base layer, so pin it to sky-500 (Ateneo) — keeps any bare
+      // `ring` utility on-brand and the emitted CSS unchanged from before.
+      ringColor: ({ theme }) => ({ DEFAULT: theme('colors.sky.500') }),
     },
   },
   plugins: [],


### PR DESCRIPTION
## What

Removes four color families from `tailwind.config.js` that the NINE redesign left with **zero references** anywhere in source:

- `blue`, `indigo`, `purple` — migration-bridge remaps that neutralized the old design's rainbow classes (all now gone)
- `mauve` — data-set extension used only by the old feature grid (deleted in the redesign)

Retained families, all still in use: `sky` (72), `gray` (128), `amber` (34), `slate` (1), `coral` (2). Ramps kept intact — Tailwind only emits referenced shades, so trimming individual stops adds churn with no build-size gain.

## Why the `ringColor` line

Tailwind's default ring color references `colors.blue.500`. Removing the `blue` remap would revert the compiled base layer's `--tw-ring-color` to **stock rainbow blue**. `ringColor.DEFAULT` is pinned to `sky-500` (Ateneo) so any bare `ring` utility stays on-brand.

## Verification

- **Emitted CSS is byte-identical to `main`** — confirmed via A/B build diff (same tree, config on vs off → `diff -q` identical). This is a pure config refactor with no source or UI change.
- Gates green: `lint`, `type-check`, `lint:plan-not-book`, `build`.
- Visual spot-check on the running preview (home + features): unchanged, no server errors. The FI chip ramp and the `ring-2 ring-current` treatment on the "7" chip render exactly as before.

## Brand-governance note

Dropping the blue/indigo/purple remaps is deliberate: a stray `bg-blue-600` should now **surface in review** rather than get silently recolored on-brand.

Closes JAR-438.

🤖 Generated with [Claude Code](https://claude.com/claude-code)