### PR TITLE
feat(JAR-439): per-route SEO meta (title, description, canonical, OG/Twitter)

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -48,6 +48,8 @@ jobs:
         run: npm i
       - name: Plan-not-book language guard
         run: npm run lint:plan-not-book
+      - name: Social meta guard
+        run: npm run lint:social-meta
       - name: Build
         run: npm run build
       - name: Setup Pages

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -30,6 +30,8 @@ jobs:
         run: npm i
       - name: Plan-not-book language guard
         run: npm run lint:plan-not-book
+      - name: Social meta guard
+        run: npm run lint:social-meta
       - name: Lint
         run: npm run lint
       - name: Build

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "preview": "vite preview",
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
     "lint:plan-not-book": "node scripts/check-plan-not-book.mjs",
+    "lint:social-meta": "node scripts/check-social-meta.mjs",
     "type-check": "tsc --noEmit"
   },
   "dependencies": {

--- a/scripts/check-social-meta.mjs
+++ b/scripts/check-social-meta.mjs
@@ -1,0 +1,84 @@
+#!/usr/bin/env node
+// Social-meta guard: fails if index.html stops shipping the route-invariant
+// link-preview tags.
+//
+// Why a guard instead of setting these in useRouteMeta(): unfurl bots
+// (iMessage, WhatsApp, Slack, Facebook, X) do not run JS, so anything the SPA
+// writes at runtime is invisible to them. Only what is served in index.html
+// counts. These four tags have the same value on every route, so they belong
+// in the static HTML, and the hook deliberately leaves them alone.
+//
+// That split is safe only while the static tags actually exist. Deleting
+// twitter:card from index.html would silently downgrade every shared link to a
+// plain text preview, with no failing type-check, lint or build to catch it,
+// which is exactly the failure mode raised in the PR #31 review. This script
+// closes that gap: the invariant is enforced rather than assumed.
+//
+// Fail closed: an unreadable or unparseable index.html is a failure, never a pass.
+
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const FILE = join(process.cwd(), 'index.html');
+
+/** attr, key, and either an exact required value or a predicate. */
+const REQUIRED = [
+  { attr: 'name', key: 'twitter:card', equals: 'summary_large_image' },
+  { attr: 'property', key: 'og:type', equals: 'website' },
+  { attr: 'property', key: 'og:site_name', equals: 'JarvisTravel' },
+  {
+    attr: 'property',
+    key: 'og:image',
+    test: (v) => /^https:\/\/\S+\.(png|jpg|jpeg|webp)$/i.test(v),
+    why: 'must be an absolute https URL to an image (scrapers do not resolve relative paths reliably)',
+  },
+];
+
+let html;
+try {
+  html = readFileSync(FILE, 'utf8');
+} catch (err) {
+  console.error(`social-meta: cannot read ${FILE}: ${err.message}`);
+  process.exit(1);
+}
+
+/** Parse every <meta> tag into { name|property -> content }. */
+function parseMeta(source) {
+  const found = new Map();
+  for (const tag of source.match(/<meta\b[^>]*>/gi) ?? []) {
+    const attr = /\b(name|property)\s*=\s*["']([^"']+)["']/i.exec(tag);
+    const content = /\bcontent\s*=\s*["']([^"']*)["']/i.exec(tag);
+    if (attr && content) found.set(`${attr[1].toLowerCase()}:${attr[2]}`, content[1]);
+  }
+  return found;
+}
+
+const meta = parseMeta(html);
+const failures = [];
+
+for (const rule of REQUIRED) {
+  const value = meta.get(`${rule.attr}:${rule.key}`);
+  if (value === undefined) {
+    failures.push(`missing <meta ${rule.attr}="${rule.key}"> in index.html`);
+    continue;
+  }
+  if (rule.equals !== undefined && value !== rule.equals) {
+    failures.push(`${rule.key} is "${value}", expected "${rule.equals}"`);
+    continue;
+  }
+  if (rule.test && !rule.test(value)) {
+    failures.push(`${rule.key} is "${value}" — ${rule.why}`);
+  }
+}
+
+if (failures.length) {
+  console.error('social-meta: index.html is missing required link-preview tags\n');
+  for (const f of failures) console.error(`  - ${f}`);
+  console.error(
+    '\nThese are route-invariant and intentionally not set by useRouteMeta(),',
+  );
+  console.error('because unfurl bots do not run JS. They must stay in index.html.');
+  process.exit(1);
+}
+
+console.log(`social-meta: ok (${REQUIRED.length} route-invariant tags present in index.html)`);

--- a/src/app/router/PageRouter.tsx
+++ b/src/app/router/PageRouter.tsx
@@ -1,4 +1,5 @@
 import { Routes, Route, Navigate } from 'react-router-dom';
+import { useRouteMeta } from '../seo/useRouteMeta';
 import { Navigation } from '../components/Navigation';
 import { Footer } from '../components/Footer';
 import { HomePage } from '../pages/HomePage';
@@ -11,6 +12,9 @@ import { TermsPage } from '../pages/TermsPage';
 import { DataSecurityPage } from '../pages/DataSecurityPage';
 
 function MarketingLayout({ children }: { children: React.ReactNode }) {
+  // Sync the document head (title, description, canonical, social tags) to the
+  // active route. Runs here because this layout wraps every marketing page.
+  useRouteMeta();
   return (
     <>
       {/* Keyboard users land here first; jumps past the nav to the content. */}

--- a/src/app/seo/routeMeta.ts
+++ b/src/app/seo/routeMeta.ts
@@ -1,0 +1,88 @@
+// Single source of truth for per-route page metadata.
+//
+// Every marketing route shares one static <head> in index.html, so without
+// this map each page reports the home page's title, description, canonical and
+// social-card tags. useRouteMeta() reads this on navigation and updates the
+// document head. A future build-time prerender step reads the same map to emit
+// static per-route HTML for scrapers that do not run JavaScript.
+//
+// Copy follows the jarvistravel-copy voice: benefit-led, plain speak, no
+// booking lexicon, no em dashes, written as if the app is live.
+
+/** Canonical origin for the marketing site. No trailing slash. */
+export const SITE_ORIGIN = 'https://jarvistravel.com';
+
+/** Shared social card until per-route cards exist. */
+export const DEFAULT_OG_IMAGE = `${SITE_ORIGIN}/og-card.png`;
+
+export interface RouteMeta {
+  /** Document title and og/twitter title. */
+  title: string;
+  /** Meta description and og/twitter description. Aim for under ~160 chars. */
+  description: string;
+}
+
+// Keyed by pathname with no trailing slash (root is '/').
+export const ROUTE_META: Record<string, RouteMeta> = {
+  '/': {
+    title: 'JarvisTravel: your vacation should be a break, not a second job',
+    description:
+      'JarvisTravel plans the pace, the budget and the map of your trip in one place, so your vacation feels like a break, not a second job.',
+  },
+  '/features': {
+    title: 'How JarvisTravel works: one plan for the pace, budget and map',
+    description:
+      'See how Jarvis paces each day, keeps the budget inside the plan, and maps your whole trip, so the tough days show up while you can still fix them.',
+  },
+  '/pricing': {
+    title: 'JarvisTravel pricing: Trip Pass and Explore',
+    description:
+      'Pick the plan that fits the way you travel. Trip Pass for a single journey, Explore for travelers who go more than once a year.',
+  },
+  '/about': {
+    title: 'About JarvisTravel: why we built it',
+    description:
+      'We started JarvisTravel because planning a trip had turned into a second job. Here is what we are building, and the promises behind it.',
+  },
+  '/contact': {
+    title: 'Contact JarvisTravel',
+    description:
+      'Reach the JarvisTravel team with a question, a press request, or a privacy note. Or join now and start planning your next trip.',
+  },
+  '/privacy': {
+    title: 'Privacy Policy: JarvisTravel',
+    description:
+      'How JarvisTravel handles your data: what we collect, what we never sell, and the choices that stay yours.',
+  },
+  '/terms': {
+    title: 'Terms of Service: JarvisTravel',
+    description: 'The terms that govern your use of JarvisTravel.',
+  },
+  '/data-security': {
+    title: 'Data Security: JarvisTravel',
+    description:
+      'How JarvisTravel protects your account and the details of your trips.',
+  },
+};
+
+/** Strip a trailing slash so '/features/' and '/features' resolve the same.
+ *  The root path stays '/'. */
+export function normalizePath(pathname: string): string {
+  if (pathname.length > 1 && pathname.endsWith('/')) {
+    return pathname.slice(0, -1);
+  }
+  return pathname;
+}
+
+/** Meta for a path, falling back to the home entry (unknown paths redirect to
+ *  '/' in the router, so this fallback is a safety net, not a real 404 page). */
+export function resolveRouteMeta(pathname: string): RouteMeta {
+  return ROUTE_META[normalizePath(pathname)] ?? ROUTE_META['/'];
+}
+
+/** Absolute canonical URL for a path. Root keeps its trailing slash to match
+ *  the value already baked into index.html. */
+export function canonicalUrl(pathname: string): string {
+  const path = normalizePath(pathname);
+  return path === '/' ? `${SITE_ORIGIN}/` : `${SITE_ORIGIN}${path}`;
+}

--- a/src/app/seo/useRouteMeta.ts
+++ b/src/app/seo/useRouteMeta.ts
@@ -1,0 +1,48 @@
+import { useEffect } from 'react';
+import { useLocation } from 'react-router-dom';
+import { canonicalUrl, resolveRouteMeta } from './routeMeta';
+
+// Upsert a <meta> tag by name or property, creating it if index.html did not
+// already ship one. Existing tags (the home defaults) are updated in place.
+function upsertMeta(attr: 'name' | 'property', key: string, content: string) {
+  let el = document.head.querySelector<HTMLMetaElement>(`meta[${attr}="${key}"]`);
+  if (!el) {
+    el = document.createElement('meta');
+    el.setAttribute(attr, key);
+    document.head.appendChild(el);
+  }
+  el.setAttribute('content', content);
+}
+
+function upsertCanonical(href: string) {
+  let el = document.head.querySelector<HTMLLinkElement>('link[rel="canonical"]');
+  if (!el) {
+    el = document.createElement('link');
+    el.setAttribute('rel', 'canonical');
+    document.head.appendChild(el);
+  }
+  el.setAttribute('href', href);
+}
+
+/** Keeps the document head in sync with the current route: title, description,
+ *  canonical, and the og/twitter title/description/url. og:image, og:type and
+ *  og:site_name are route-invariant and stay as shipped in index.html.
+ *  Call once from the layout that wraps every page. */
+export function useRouteMeta() {
+  const { pathname } = useLocation();
+  useEffect(() => {
+    const meta = resolveRouteMeta(pathname);
+    const url = canonicalUrl(pathname);
+
+    document.title = meta.title;
+    upsertMeta('name', 'description', meta.description);
+    upsertCanonical(url);
+
+    upsertMeta('property', 'og:title', meta.title);
+    upsertMeta('property', 'og:description', meta.description);
+    upsertMeta('property', 'og:url', url);
+
+    upsertMeta('name', 'twitter:title', meta.title);
+    upsertMeta('name', 'twitter:description', meta.description);
+  }, [pathname]);
+}

--- a/src/app/seo/useRouteMeta.ts
+++ b/src/app/seo/useRouteMeta.ts
@@ -2,9 +2,20 @@ import { useEffect } from 'react';
 import { useLocation } from 'react-router-dom';
 import { canonicalUrl, resolveRouteMeta } from './routeMeta';
 
+/** Every key this module writes. A closed union rather than `string` so the
+ *  attribute selector below cannot be handed a quote or bracket: a bad key is
+ *  a type error, not a malformed selector at runtime. (PR #31 review, nit 2.) */
+type MetaKey =
+  | 'description'
+  | 'og:title'
+  | 'og:description'
+  | 'og:url'
+  | 'twitter:title'
+  | 'twitter:description';
+
 // Upsert a <meta> tag by name or property, creating it if index.html did not
 // already ship one. Existing tags (the home defaults) are updated in place.
-function upsertMeta(attr: 'name' | 'property', key: string, content: string) {
+function upsertMeta(attr: 'name' | 'property', key: MetaKey, content: string) {
   let el = document.head.querySelector<HTMLMetaElement>(`meta[${attr}="${key}"]`);
   if (!el) {
     el = document.createElement('meta');
@@ -25,8 +36,15 @@ function upsertCanonical(href: string) {
 }
 
 /** Keeps the document head in sync with the current route: title, description,
- *  canonical, and the og/twitter title/description/url. og:image, og:type and
- *  og:site_name are route-invariant and stay as shipped in index.html.
+ *  canonical, and the og/twitter title/description/url.
+ *
+ *  Deliberately NOT written here: `twitter:card`, `og:image`, `og:type` and
+ *  `og:site_name`. Their values are the same on every route, so they ship once
+ *  in index.html and are never touched. Rewriting a constant on each navigation
+ *  would only imply it varies. `npm run lint:social-meta` fails the build if any
+ *  of them goes missing from index.html, which is the case this hook would
+ *  otherwise have to defend against. (PR #31 review.)
+ *
  *  Call once from the layout that wraps every page. */
 export function useRouteMeta() {
   const { pathname } = useLocation();


### PR DESCRIPTION
## Problem

All 8 marketing routes share the single static `<head>` in `index.html`, so every page reports the **home page's** title, description, canonical and OG/Twitter tags. Every shared link previews as the home page, and search engines see one title for the whole site.

## What

- `src/app/seo/routeMeta.ts` — single source-of-truth map of per-route `{ title, description }` for all 8 routes, plus `canonicalUrl()` / `resolveRouteMeta()` helpers (origin + path).
- `src/app/seo/useRouteMeta.ts` — dependency-free hook that updates `document.title`, `meta[name=description]`, `link[rel=canonical]`, and the `og:`/`twitter:` title/description/url on every navigation. Existing tags are updated in place.
- Wired once into `MarketingLayout` (wraps every page). `og:image`, `og:type`, `og:site_name` are route-invariant and untouched.

Per-route copy follows the jarvistravel-copy voice: benefit-led, plain speak, no booking lexicon, no em dashes, written as if the app is live.

## Verification

On the running preview:
- Direct load of `/pricing` → head reflects pricing (title, description, canonical `/pricing`, og:url, twitter).
- In-app nav `/pricing` → `/about` → full head switches to about, browser tab title with it.

Gates green: `lint`, `type-check`, `lint:plan-not-book`, `build`. No visual/UI change.

## Scope

Fixes real browsers and JS-rendering crawlers (incl. Googlebot). Non-JS social scrapers still read the static `index.html` until static prerender lands.

## Follow-up (separate ticket)

Build-time **prerender** so each route ships static per-route HTML for non-JS scrapers. It consumes this same meta map (this PR is its foundation, not throwaway). Deferred because the prerender approach is coupled to the still-open hosting/infra decision.

Closes JAR-439.

🤖 Generated with [Claude Code](https://claude.com/claude-code)