### PR TITLE
fix(JAR-70): correct Trip Pass price to $24.99

### DIFF
--- a/src/app/pages/PricingPage.tsx
+++ b/src/app/pages/PricingPage.tsx
@@ -103,7 +103,7 @@ export function PricingPage() {
                     tripActive ? 'text-gray-50' : 'text-gray-900'
                   }`}
                 >
-                  $24.95
+                  $24.99
                 </span>
                 <span
                   className={`ml-2 transition-colors ${


### PR DESCRIPTION
## What

The pricing page advertised Trip Pass at **\$24.95**. The app, the backend plan model, and JAR-71 all carry **\$24.99**. Marketing was the outlier — we were publishing a price we would not charge.

One character: `$24.95` → `$24.99` in `PricingPage.tsx`.

## What is not in this PR

Explore+ pricing (\$99/year, \$11.95/month) is unchanged — both were already correct.

## Verification

`npm run type-check` and `npm run build` both green.

## Note for the reviewer

These numbers are still hardcoded in the page. Clerk Billing is the source of truth for prices, and this is the second time the site has drifted from it. Worth a follow-up that renders the page from the checked-in Clerk billing config so drift becomes a failing diff rather than a wrong price on a public page.

Ticket: JAR-70

🤖 Generated with [Claude Code](https://claude.com/claude-code)