### PR TITLE
fix(JAR-656): tighten two home page copy lines

### DIFF
--- a/src/app/pages/HomePage.tsx
+++ b/src/app/pages/HomePage.tsx
@@ -233,7 +233,7 @@ export function HomePage() {
         <div className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 py-16 md:py-20">
           <div className="max-w-2xl mb-12">
             <h2 className="text-3xl md:text-4xl font-bold text-gray-900 [text-wrap:balance] mb-4">
-              One plan, instead of twelve tabs.
+              One plan, not twelve tabs.
             </h2>
             <p className="text-lg text-gray-600 leading-relaxed">
               Everything that makes a trip work, and everything you&rsquo;d
@@ -287,7 +287,7 @@ export function HomePage() {
                 No ads, ever.
               </h3>
               <p className="text-gray-600 leading-relaxed">
-                Your plan isn&rsquo;t a billboard.
+                Your plan doesn&rsquo;t need billboards.
               </p>
             </li>
             <li className="py-6 border-b border-gray-200">


### PR DESCRIPTION
Brand-owner copy edits on the home page. Copy only, no markup or styling changes.

## Changes

**Section heading** (`HomePage.tsx:236`)

```diff
- One plan, instead of twelve tabs.
+ One plan, not twelve tabs.
```

**Three promises, under "No ads, ever."** (`HomePage.tsx:290`)

```diff
- Your plan isn't a billboard.
+ Your plan doesn't need billboards.
```

Both cut a weak connective and land harder. The second also shifts the promise from a metaphor about what the plan *is* to a statement about what it *needs*.

Apostrophe kept as the `&rsquo;` entity to match the surrounding file.

## Verification

Checked against the running preview rather than just the source. The rendered DOM reads:

> One plan, not twelve tabs.

> No ads, ever.
> Your plan doesn't need billboards.

Gates green: `type-check`, `lint`, `lint:plan-not-book`, `build`.

## Follow-up

"Your plan isn't a billboard." is written into the `jarvistravel-copy` skill as an approved plain-speak example. That reference needs the same update, or it will keep steering future copy back to the retired line. Not touched here since it lives outside this repo.

Closes JAR-656.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
