### PR TITLE
feat(pricing): render prices from one source, and fail when it drifts [JAR-660]

### DIFF
--- a/.github/workflows/deploy-droplet.yml
+++ b/.github/workflows/deploy-droplet.yml
@@ -39,6 +39,14 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      # Stripe-side drift happens after merge: a price edited in the dashboard
+      # makes no PR, so a green PR check says nothing about what is about to be
+      # deployed. Reconcile again here, immediately before shipping.
+      - name: Pricing guard
+        run: npm run lint:prices
+        env:
+          STRIPE_API_KEY: ${{ secrets.STRIPE_API_KEY }}
+
       - name: Build
         run: npm run build
 

--- a/.github/workflows/deploy-droplet.yml
+++ b/.github/workflows/deploy-droplet.yml
@@ -43,7 +43,7 @@ jobs:
       # makes no PR, so a green PR check says nothing about what is about to be
       # deployed. Reconcile again here, immediately before shipping.
       - name: Pricing guard
-        run: npm run lint:prices
+        run: npm run lint:prices -- --network-warn
         env:
           STRIPE_API_KEY: ${{ secrets.STRIPE_API_KEY }}
 

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -53,6 +53,25 @@ jobs:
 
       - name: OG card is the real lockup
         run: npm run lint:og-card
+      # Pricing guard — this is the Pages shipping path, so it must carry the
+      # same drift gate as the droplet deploy (review deleg_dd2f886e Sec-M1 /
+      # Design-F4: previously the guard only gated deploy-droplet, so drifted
+      # prices shipped unguarded to the Pages URL). --network-warn: a Stripe
+      # outage must not block shipping; a verified mismatch still fails.
+      - name: Assert the pricing secret is configured
+        run: |
+          if [ -z "$STRIPE_API_KEY" ]; then
+            echo "::error::STRIPE_API_KEY repo secret is not configured. The pricing guard"
+            echo "::error::cannot reconcile against Stripe without it, and a green check here"
+            echo "::error::would mean nothing. Add a restricted, read-only test-mode key."
+            exit 1
+          fi
+        env:
+          STRIPE_API_KEY: ${{ secrets.STRIPE_API_KEY }}
+      - name: Pricing guard
+        run: npm run lint:prices -- --network-warn
+        env:
+          STRIPE_API_KEY: ${{ secrets.STRIPE_API_KEY }}
       - name: Build
         run: npm run build
       - name: Setup Pages

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -1,6 +1,9 @@
 # PR quality gate — runs on every non-main branch push so non-compliant copy is
 # caught at review time, not at deploy (PR #21 review, M1). Main pushes are
-# covered by node.js.yml (the deploy re-runs the guards as the final gate).
+# covered by node.js.yml + deploy-droplet.yml (both re-run the guards,
+# including the pricing drift gate, as the final gate). The daily schedule
+# catches Stripe-side drift that makes no PR and no deploy (review
+# deleg_dd2f886e Design-F4b).
 name: PR checks
 
 on:
@@ -12,9 +15,13 @@ on:
     #    exclusion: fork PRs never execute anything.
     # 2. No ruleset requires this check (marketing has no required status
     #    checks — org 'Protections for MAIN' has none). The check is
-    #    prophylaxis; main pushes are already guarded by node.js.yml, so
-    #    branches-ignore avoids doubling the guard on the 2-runner fleet.
+    #    prophylaxis; main pushes are already guarded by the deploy workflows,
+    #    so branches-ignore avoids doubling the guard on the 2-runner fleet.
     branches-ignore: ['main']
+  schedule:
+    # Daily drift sweep: a Stripe dashboard price edit makes no PR, so without
+    # this, drift sits undiscovered until the next deploy.
+    - cron: '0 6 * * *'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -38,6 +38,26 @@ jobs:
           cache: 'npm'
       - name: Install dependencies
         run: npm i
+      # Two halves: the literal scan always runs; the Stripe reconciliation
+      # needs STRIPE_API_KEY (restricted, read-only).
+      # The guard's promise is "fail when the site and Stripe drift". It can only
+      # keep that promise if the secret exists, so its absence is a failure here
+      # rather than a skip — this step passed vacuously on every PR while the
+      # secret was unconfigured, and the log said SKIPPED where nobody read it.
+      - name: Assert the pricing secret is configured
+        run: |
+          if [ -z "$STRIPE_API_KEY" ]; then
+            echo "::error::STRIPE_API_KEY repo secret is not configured. The pricing guard"
+            echo "::error::cannot reconcile against Stripe without it, and a green check here"
+            echo "::error::would mean nothing. Add a restricted, read-only test-mode key."
+            exit 1
+          fi
+        env:
+          STRIPE_API_KEY: ${{ secrets.STRIPE_API_KEY }}
+      - name: Pricing guard
+        run: npm run lint:prices
+        env:
+          STRIPE_API_KEY: ${{ secrets.STRIPE_API_KEY }}
       - name: Plan-not-book language guard
         run: npm run lint:plan-not-book
       - name: Social meta guard

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,6 +39,30 @@ npm run type-check   # tsc --noEmit
 npm run lint         # eslint with zero-warnings policy
 ```
 
+### Pricing (single source of truth — JAR-660)
+
+The only place this site knows what anything costs is `src/app/data/pricing.ts`,
+which mirrors Stripe (account `acct_1ToBJsPDaNqc0Lek`, keyed by the same
+`lookup_key` the backend resolves at checkout). The `lint:prices` guard fails
+CI when the site and Stripe disagree; `check-prices.mjs` also fails when a
+dollar amount reappears as a literal in a component.
+
+**Changing a price or adding a plan (runbook):**
+1. Edit/create the price in the Stripe dashboard (test mode; same lookup_key
+   in live mode at launch).
+2. `STRIPE_API_KEY=rk_test_... npm run sync:prices` — regenerates the
+   generated block in `pricing.ts` from Stripe (the `Price` type + the guard's
+   `EXPECTED_KEYS` fail loudly if the catalogue shape changes; `interval_count
+   != 1` is refused — the site cannot render it).
+3. Update `PriceLookupKey` + `EXPECTED_KEYS` in `check-prices.mjs` if the key
+   set changed.
+4. Open the PR — `pr-checks` runs the guard (literal scan + Stripe
+   reconciliation). The droplet + Pages deploys re-run it immediately before
+   shipping (`--network-warn`: a Stripe outage warns; a verified mismatch
+   fails).
+5. The daily `pr-checks` schedule (06:00 UTC) catches Stripe-side edits that
+   make no PR.
+
 ### Base path & routing
 
 - Routes are served at the domain root (`/`) on both deployments (configured in `vite.config.ts` and `tsconfig.json`)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,7 +42,9 @@ npm run lint         # eslint with zero-warnings policy
 ### Pricing (single source of truth — JAR-660)
 
 The only place this site knows what anything costs is `src/app/data/pricing.ts`,
-which mirrors Stripe (account `acct_1ToBJsPDaNqc0Lek`, keyed by the same
+which mirrors Stripe (the org sandbox `acct_1ToBK0ABsvYNMJZ0`; at live launch
+the catalogue is re-minted in the org's live account and the pins move with
+it — keyed by the same
 `lookup_key` the backend resolves at checkout). The `lint:prices` guard fails
 CI when the site and Stripe disagree; `check-prices.mjs` also fails when a
 dollar amount reappears as a literal in a component.

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "logo:gen": "node scripts/gen-logo-component.mjs",
     "logo:check": "node scripts/gen-logo-component.mjs --check",
     "logo:vendor": "node scripts/vendor-logo.mjs",
-    "test:scripts": "node scripts/__tests__/gen-logo-component.test.mjs && node scripts/__tests__/check-plan-not-book.test.mjs",
+    "test:scripts": "node scripts/__tests__/gen-logo-component.test.mjs && node scripts/__tests__/check-plan-not-book.test.mjs && node scripts/__tests__/check-prices.test.mjs",
     "type-check": "tsc --noEmit",
     "lint:prices": "node scripts/check-prices.mjs",
     "sync:prices": "node scripts/check-prices.mjs --write"

--- a/package.json
+++ b/package.json
@@ -15,7 +15,9 @@
     "logo:check": "node scripts/gen-logo-component.mjs --check",
     "logo:vendor": "node scripts/vendor-logo.mjs",
     "test:scripts": "node scripts/__tests__/gen-logo-component.test.mjs",
-    "type-check": "tsc --noEmit"
+    "type-check": "tsc --noEmit",
+    "lint:prices": "node scripts/check-prices.mjs",
+    "sync:prices": "node scripts/check-prices.mjs --write"
   },
   "dependencies": {
     "lucide-react": "^0.460.0",

--- a/scripts/__tests__/check-prices.test.mjs
+++ b/scripts/__tests__/check-prices.test.mjs
@@ -1,0 +1,99 @@
+#!/usr/bin/env node
+// Test what the pricing guard SAYS when it cannot read /v1/account.
+//
+// The account pin exists because a catalogue was once minted into a personal
+// Stripe account the org cannot see or manage, under the same lookup keys at
+// the same amounts — right prices, wrong Stripe, green check (JAR-659/660).
+//
+// When the CI key is both under-scoped AND for the wrong account, Stripe's
+// permission error is the only thing that answers "which account is this key
+// for" — it names the account inline. Reporting just the missing permission
+// sends the reader to the dashboard to grant it and buys a second failing run
+// that finally names the real problem. Each round trip is minutes of CI, and
+// this exact pair is what marketing#36 hit.
+//
+// So this asserts the message, not the fetch: given a permission error naming a
+// foreign account, the guard must say BOTH things at once.
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const ROOT = new URL('../..', import.meta.url).pathname;
+const SCRIPT = resolve(ROOT, 'scripts/check-prices.mjs');
+
+let passed = 0;
+let failed = 0;
+function test(name, fn) {
+  try {
+    fn();
+    passed++;
+    console.log(`  ✓ ${name}`);
+  } catch (e) {
+    failed++;
+    console.error(`  ✗ ${name}\n    ${e.message}`);
+  }
+}
+
+const source = readFileSync(SCRIPT, 'utf8');
+
+/** The account this repo's catalogue is pinned to, read from the guard itself
+ *  so the test cannot drift from the pin it is describing. */
+const EXPECTED_ACCOUNT = source.match(/const EXPECTED_ACCOUNT = '(acct_[A-Za-z0-9]+)'/)?.[1];
+
+/**
+ * Reproduce the guard's extraction against a real Stripe error string.
+ * The regex is read out of the source rather than copied, so a change to the
+ * guard's pattern is tested rather than shadowed by a stale duplicate.
+ */
+const NAMED_ACCOUNT_RE = (() => {
+  const literal = source.match(/message\.match\((\/.+?\/)\)/)?.[1];
+  if (!literal) throw new Error('could not find the account-extraction regex in check-prices.mjs');
+  const body = literal.slice(1, literal.lastIndexOf('/'));
+  return new RegExp(body);
+})();
+
+// The verbatim shape Stripe returns for an under-scoped restricted key.
+const STRIPE_PERMISSION_ERROR =
+  "Permission denied. The provided key 'rk_test_XXXX' does not have the required " +
+  "permissions for this endpoint on account 'acct_1ToBJsPDaNqc0Lek'. Enabling " +
+  '"Basic Business Contact Information Read" (\'accounts_kyc_basic_read\') permissions ' +
+  'on this key would allow this request to continue.';
+
+console.log('check-prices: account-pin diagnostics');
+
+test('the guard pins an account at all', () => {
+  if (!EXPECTED_ACCOUNT) throw new Error('EXPECTED_ACCOUNT is missing — the wrong-Stripe trap is unguarded');
+});
+
+test("extracts the key's own account from Stripe's permission error", () => {
+  const named = STRIPE_PERMISSION_ERROR.match(NAMED_ACCOUNT_RE)?.[1];
+  if (named !== 'acct_1ToBJsPDaNqc0Lek') {
+    throw new Error(`extracted ${named ?? 'nothing'}, want acct_1ToBJsPDaNqc0Lek`);
+  }
+});
+
+test('recognises that account as NOT the pinned one', () => {
+  const named = STRIPE_PERMISSION_ERROR.match(NAMED_ACCOUNT_RE)?.[1];
+  if (named === EXPECTED_ACCOUNT) {
+    throw new Error('the fixture account equals the pin, so this test proves nothing');
+  }
+});
+
+test('the failure path reports the wrong account, not only the permission', () => {
+  // The guard must contain the both-problems branch, keyed on the comparison.
+  if (!/named && named !== EXPECTED_ACCOUNT/.test(source)) {
+    throw new Error('no branch compares the key\'s account against the pin on the permission-error path');
+  }
+  if (!/permission alone will not fix this/i.test(source)) {
+    throw new Error('the message does not tell the reader the permission alone is not the fix');
+  }
+});
+
+test('a matching account produces no extra noise', () => {
+  const sameAccount = STRIPE_PERMISSION_ERROR.replace('acct_1ToBJsPDaNqc0Lek', EXPECTED_ACCOUNT);
+  const named = sameAccount.match(NAMED_ACCOUNT_RE)?.[1];
+  if (named !== EXPECTED_ACCOUNT) throw new Error('extraction broke on the matching-account case');
+  // The guard's branch is `named !== EXPECTED_ACCOUNT`, so this case adds nothing.
+});
+
+console.log(`\n${passed} passed, ${failed} failed`);
+if (failed > 0) process.exit(1);

--- a/scripts/check-prices.mjs
+++ b/scripts/check-prices.mjs
@@ -19,12 +19,14 @@
 // a failure, never a pass.
 
 import { readFileSync, writeFileSync, readdirSync, statSync } from 'node:fs';
-import { join, extname } from 'node:path';
+import { join, extname, sep } from 'node:path';
 
 const ROOT = process.cwd();
 const PRICING_FILE = join(ROOT, 'src/app/data/pricing.ts');
 const COMPONENT_DIRS = ['src/app/pages', 'src/app/components', 'src/app'];
 const WRITE = process.argv.includes('--write');
+// Skipping the Stripe half has to be asked for. See the STRIPE_API_KEY branch.
+const ALLOW_SKIP = process.argv.includes('--allow-skip');
 
 const fail = (msg) => {
   console.error(`prices: ${msg}`);
@@ -65,7 +67,9 @@ for (const dir of COMPONENT_DIRS) {
   for (const rel of sourceFiles(dir)) {
     if (scanned.has(rel)) continue;
     scanned.add(rel);
-    if (rel === 'src/app/data/pricing.ts') continue; // the one place amounts belong
+    // Normalise separators: join() yields backslashes on Windows, so comparing
+    // against a forward-slash literal silently failed to exclude the file.
+    if (rel.split(sep).join('/') === 'src/app/data/pricing.ts') continue; // the one place amounts belong
 
     const text = readFileSync(join(ROOT, rel), 'utf8');
     text.split('\n').forEach((line, i) => {
@@ -100,10 +104,31 @@ console.log(`prices: ok — no amount literals in ${scanned.size} component file
 // wrong Stripe, green check.
 const EXPECTED_ACCOUNT = 'acct_1ToBJsPDaNqc0Lek';
 
+// The three keys this catalogue is defined as having. Asserted as an exact set
+// below, so a key *deleted* from pricing.ts fails here rather than at runtime
+// when priceOf() reaches into undefined.
+const EXPECTED_KEYS = ['jt_trip_pass', 'jt_explore_annual', 'jt_explore_monthly'];
+
 const KEY = process.env.STRIPE_API_KEY;
 if (!KEY) {
-  console.log('prices: SKIPPED the Stripe reconciliation — STRIPE_API_KEY is not set.');
-  console.log('        Set a restricted, read-only key to verify the amounts really match.');
+  // Fail closed. A guard whose whole promise is "fail when it drifts" must not
+  // report success when it did not check — and it did exactly that in CI,
+  // because the repo secret was never configured: every PR got a green
+  // "SKIPPED the Stripe reconciliation" and nobody looked again.
+  //
+  // Local runs without a key are legitimate, so they can opt out explicitly.
+  // CI cannot: there is no reading of an unset secret that means "verified".
+  if (!ALLOW_SKIP) {
+    console.error('prices: STRIPE_API_KEY is not set, so the Stripe reconciliation did not run.');
+    console.error('');
+    console.error('  In CI: configure the STRIPE_API_KEY repo secret (restricted, read-only, test mode).');
+    console.error('  Locally: pass --allow-skip to run only the literal scan.');
+    console.error('');
+    console.error('Exiting non-zero rather than passing as if the amounts had been checked.');
+    process.exit(1);
+  }
+  console.log('prices: SKIPPED the Stripe reconciliation — STRIPE_API_KEY is not set (--allow-skip).');
+  console.log('        The literal scan above still ran. Amounts were NOT verified against Stripe.');
   process.exit(0);
 }
 if (KEY.includes('_live_')) fail('refusing to run against a live key — use a restricted test key');
@@ -120,13 +145,55 @@ const BLOCK = /\/\/ BEGIN GENERATED PRICES[\s\S]*?\/\/ END GENERATED PRICES/;
 const block = module_.match(BLOCK);
 if (!block) fail('pricing.ts has no BEGIN/END GENERATED PRICES block to reconcile');
 
+// Parsing has to be all-or-nothing. Anything this regex fails to understand is
+// an amount rendered on the site that nothing compared against Stripe, and the
+// old `local.size === 0` check only caught the case where *every* entry broke.
+// One malformed entry — reordered fields, a numeric separator like 2_499 — was
+// silently dropped and the guard still reported ok.
+const ENTRY =
+  /(\w+):\s*\{\s*lookupKey:\s*'([^']+)',\s*amountCents:\s*(\d+),\s*currency:\s*'([^']+)',\s*interval:\s*(null|'[^']+')\s*\}/g;
+
 const local = new Map();
-for (const m of block[0].matchAll(
-  /(\w+):\s*\{\s*lookupKey:\s*'([^']+)',\s*amountCents:\s*(\d+),\s*currency:\s*'([^']+)',\s*interval:\s*(null|'[^']+')/g,
-)) {
-  local.set(m[2], { amountCents: Number(m[3]), currency: m[4], interval: m[5].replace(/'/g, '') });
+for (const m of block[0].matchAll(ENTRY)) {
+  const [, propName, lookupKey, amount, currency, interval] = m;
+  // Key by the property name, and require the lookupKey to agree with it.
+  // Keying by the lookupKey value let a typo'd entry — jt_trip_pass pointing at
+  // 'jt_explore_annual' — collapse two entries into one. Both survivors matched
+  // Stripe, the guard passed, and the site rendered an unverified $24.99.
+  if (propName !== lookupKey) {
+    fail(`pricing.ts: entry '${propName}' has lookupKey '${lookupKey}' — they must be identical`);
+  }
+  if (local.has(propName)) fail(`pricing.ts: '${propName}' is defined more than once`);
+  local.set(propName, {
+    amountCents: Number(amount),
+    currency,
+    interval: interval.replace(/'/g, ''),
+  });
 }
-if (local.size === 0) fail('could not parse any prices out of pricing.ts');
+
+// Every top-level `name: {` in the block must have been understood above.
+const declared = [...block[0].matchAll(/^\s{2}(\w+):\s*\{/gm)].map((m) => m[1]);
+const unparsed = declared.filter((name) => !local.has(name));
+if (unparsed.length) {
+  fail(
+    `pricing.ts: could not parse ${unparsed.join(', ')} — the guard would have skipped ` +
+      'them and reported ok. Fix the entry, or the parser if the shape changed.',
+  );
+}
+
+// And the set has to be exactly what we expect: a *deleted* key used to pass,
+// because the remaining entries still matched Stripe. priceOf() then hit
+// undefined.amountCents and took the pricing page down at runtime.
+const missing = EXPECTED_KEYS.filter((k) => !local.has(k));
+const extra = [...local.keys()].filter((k) => !EXPECTED_KEYS.includes(k));
+if (missing.length || extra.length) {
+  fail(
+    'pricing.ts does not define exactly the expected catalogue' +
+      (missing.length ? `\n  missing: ${missing.join(', ')}` : '') +
+      (extra.length ? `\n  unexpected: ${extra.join(', ')}` : '') +
+      '\n  If the catalogue really changed, update EXPECTED_KEYS and PriceLookupKey together.',
+  );
+}
 
 async function assertAccount() {
   const res = await fetch('https://api.stripe.com/v1/account', {
@@ -177,18 +244,45 @@ for (const [key, want] of local) {
   if (gotInterval !== (want.interval === 'null' ? null : want.interval)) {
     mismatches.push(`${key}: site says interval ${want.interval}, Stripe says ${gotInterval}`);
   }
+  // currency was parsed and then never compared, so a price flipped to another
+  // currency in Stripe passed green while the site kept rendering a $ sign.
+  if (got.currency !== want.currency) {
+    mismatches.push(`${key}: site says ${want.currency}, Stripe says ${got.currency}`);
+  }
 }
 
 if (WRITE) {
+  // Everything below is interpolated into a committed .ts file, so every field
+  // is validated before it gets there. Values arriving from an API are not
+  // trusted source code: a leaked restricted key plus `npm run sync:prices`
+  // would otherwise be enough to write arbitrary TypeScript into the repo via
+  // a currency of `usd' }, evil: {`. The guard would then pass, because it
+  // checks that the file agrees with Stripe, not that Stripe is sane.
+  const STRIPE_INTERVALS = ['day', 'week', 'month', 'year'];
   const lines = [...local.keys()].map((key) => {
     const got = remote.get(key);
     if (!got) fail(`cannot rewrite: Stripe has no active price with lookup_key ${key}`);
-    const interval = got.recurring?.interval ? `'${got.recurring.interval}'` : 'null';
+
+    if (!/^[a-z0-9_]+$/.test(got.lookup_key ?? '')) {
+      fail(`cannot rewrite: Stripe lookup_key ${JSON.stringify(got.lookup_key)} is not [a-z0-9_]`);
+    }
+    if (!Number.isSafeInteger(got.unit_amount) || got.unit_amount <= 0) {
+      fail(`cannot rewrite: ${key} has unit_amount ${JSON.stringify(got.unit_amount)}`);
+    }
+    if (got.currency !== 'usd') {
+      fail(`cannot rewrite: ${key} is ${JSON.stringify(got.currency)}, expected usd`);
+    }
+    const rawInterval = got.recurring?.interval ?? null;
+    if (rawInterval !== null && !STRIPE_INTERVALS.includes(rawInterval)) {
+      fail(`cannot rewrite: ${key} has interval ${JSON.stringify(rawInterval)}`);
+    }
+
+    const interval = rawInterval ? `'${rawInterval}'` : 'null';
     return `  ${key}: { lookupKey: '${key}', amountCents: ${got.unit_amount}, currency: '${got.currency}', interval: ${interval} },`;
   });
   const rebuilt = [
     '// BEGIN GENERATED PRICES — npm run sync:prices',
-    'export const PRICES: Record<PriceLookupKey, Price> = {',
+    'export const PRICES: Readonly<Record<PriceLookupKey, Price>> = {',
     ...lines,
     '};',
     '// END GENERATED PRICES',

--- a/scripts/check-prices.mjs
+++ b/scripts/check-prices.mjs
@@ -27,6 +27,9 @@ const COMPONENT_DIRS = ['src/app/pages', 'src/app/components', 'src/app'];
 const WRITE = process.argv.includes('--write');
 // Skipping the Stripe half has to be asked for. See the STRIPE_API_KEY branch.
 const ALLOW_SKIP = process.argv.includes('--allow-skip');
+// Deploy-time mode: a network/API outage warns instead of failing the deploy
+// (pr-checks stays strict). A verified mismatch still fails in both modes.
+const NETWORK_WARN = process.argv.includes('--network-warn');
 
 const fail = (msg) => {
   console.error(`prices: ${msg}`);
@@ -39,6 +42,11 @@ const fail = (msg) => {
 // a false positive is a five-second conversation, a false negative is a wrong
 // price on the public site.
 const MONEY = /\$\s?\d[\d,]*(?:\.\d{2})?/g;
+
+// The "doing it right" escape hatch: formatPrice(2499) renders $24.99 with no
+// $ literal in the file — the natural next move for a dev reintroducing a
+// hardcoded amount (review deleg_dd2f886e). Flag it too.
+const HARDCODED_FORMAT = /formatPrice\s*\(\s*['"\d]/;
 
 function sourceFiles(dir) {
   const out = [];
@@ -72,11 +80,35 @@ for (const dir of COMPONENT_DIRS) {
     if (rel.split(sep).join('/') === 'src/app/data/pricing.ts') continue; // the one place amounts belong
 
     const text = readFileSync(join(ROOT, rel), 'utf8');
+    let inBlockComment = false;
     text.split('\n').forEach((line, i) => {
       // Comments explaining the history are allowed to name old prices.
-      const code = line.replace(/\/\/.*$/, '').replace(/\/\*.*?\*\//g, '');
+      // Stateful: a multi-line /* ... */ block is stripped across lines, not
+      // just per-line (review deleg_dd2f886e — a $24.95 in a narrative block
+      // comment was a false positive).
+      let code = line;
+      if (inBlockComment) {
+        const end = code.indexOf('*/');
+        if (end === -1) return; // still inside the block
+        code = code.slice(end + 2);
+        inBlockComment = false;
+      }
+      const start = code.indexOf('/*');
+      if (start !== -1) {
+        const end = code.indexOf('*/', start + 2);
+        if (end === -1) {
+          code = code.slice(0, start);
+          inBlockComment = true;
+        } else {
+          code = code.slice(0, start) + code.slice(end + 2);
+        }
+      }
+      code = code.replace(/\/\/.*$/, '');
       for (const hit of code.match(MONEY) ?? []) {
         literalHits.push(`${rel}:${i + 1}  ${hit}  ${line.trim().slice(0, 80)}`);
+      }
+      if (HARDCODED_FORMAT.test(code)) {
+        literalHits.push(`${rel}:${i + 1}  formatPrice(<literal>)  ${line.trim().slice(0, 80)}`);
       }
     });
   }
@@ -131,7 +163,13 @@ if (!KEY) {
   console.log('        The literal scan above still ran. Amounts were NOT verified against Stripe.');
   process.exit(0);
 }
-if (KEY.includes('_live_')) fail('refusing to run against a live key — use a restricted test key');
+if (KEY.includes('_live_') && WRITE) {
+  fail('refusing to write from a live key — use a restricted test key');
+}
+// Check-only mode may use a live restricted key: the account pin survives the
+// test→live toggle (same acct id), and launch-time catalogue verification is
+// exactly what the guard is for (review deleg_dd2f886e F1). Writing is still
+// banned — regenerate only from test.
 
 let module_;
 try {
@@ -195,15 +233,54 @@ if (missing.length || extra.length) {
   );
 }
 
+// Fetch with a 10s timeout and 2 retries with backoff. A Stripe incident or
+// blackholed connection must not hang a job or fail every PR/deploy on a
+// transient (review deleg_dd2f886e Sec-M2 / Design-F5). With --network-warn
+// (deploy time) an unreachable Stripe warns and exits 0 — pr-checks stays
+// strict, so drift still fails the PR; a deploy is not blocked by an outage
+// for a copy-fix unrelated to pricing.
+async function stripeFetch(path) {
+  const attempts = 3;
+  for (let i = 0; i < attempts; i++) {
+    const ac = new AbortController();
+    const timer = setTimeout(() => ac.abort(), 10_000);
+    try {
+      const res = await fetch(`https://api.stripe.com${path}`, {
+        headers: { Authorization: `Bearer ${KEY}` },
+        signal: ac.signal,
+      });
+      clearTimeout(timer);
+      if (res.status === 429 || res.status >= 500) {
+        throw new Error(`Stripe transient error ${res.status}`);
+      }
+      return res;
+    } catch (err) {
+      clearTimeout(timer);
+      if (i < attempts - 1) {
+        await new Promise((r) => setTimeout(r, 500 * 2 ** i));
+        continue;
+      }
+      if (NETWORK_WARN) {
+        console.error(
+          `prices: WARNING — could not verify against Stripe (${err.message}). ` +
+            'Deploy continues; pr-checks will fail on the next push.',
+        );
+        process.exit(0);
+      }
+      fail(`cannot reach Stripe (${err.message}) after ${attempts} attempts`);
+    }
+  }
+  fail('unreachable');
+}
+
 async function assertAccount() {
-  const res = await fetch('https://api.stripe.com/v1/account', {
-    headers: { Authorization: `Bearer ${KEY}` },
-  });
+  const res = await stripeFetch('/v1/account');
   const body = await res.json();
   if (!res.ok) {
     // Not knowing which account we are reading is itself the failure.
     fail(`cannot read /v1/account (${body?.error?.message ?? res.status}).\n` +
-      `       Add the "Account" read permission to this restricted key.\n` +
+      `       Add the "Basic Business Contact Information Read" permission\n` +
+      `       (accounts_kyc_basic_read) to this restricted key.\n` +
       `       Without it this check cannot confirm it is reading ${EXPECTED_ACCOUNT}.`);
   }
   if (body.id !== EXPECTED_ACCOUNT) {
@@ -213,12 +290,22 @@ async function assertAccount() {
 }
 
 async function stripePrices() {
-  const res = await fetch('https://api.stripe.com/v1/prices?limit=100&active=true', {
-    headers: { Authorization: `Bearer ${KEY}` },
-  });
-  const body = await res.json();
-  if (!res.ok) fail(`Stripe error (${res.status}): ${body?.error?.message ?? 'unknown'}`);
-  return body.data ?? [];
+  // Page through: Stripe mints a new active Price on every change, so the
+  // active catalogue grows monotonically — a single limit=100 page truncates
+  // the comparison (review deleg_dd2f886e B&L-F6 / Design-F7).
+  const out = [];
+  let startingAfter;
+  for (;;) {
+    const q = new URLSearchParams({ active: 'true', limit: '100' });
+    if (startingAfter) q.set('starting_after', startingAfter);
+    const res = await stripeFetch(`/v1/prices?${q}`);
+    const body = await res.json();
+    if (!res.ok) fail(`Stripe error (${res.status}): ${body?.error?.message ?? 'unknown'}`);
+    out.push(...(body.data ?? []));
+    if (!body.has_more || !body.data?.length) break;
+    startingAfter = body.data[body.data.length - 1].id;
+  }
+  return out;
 }
 
 await assertAccount();
@@ -273,6 +360,16 @@ if (WRITE) {
     }
     if (!Number.isSafeInteger(got.unit_amount) || got.unit_amount <= 0) {
       fail(`cannot rewrite: ${key} has unit_amount ${JSON.stringify(got.unit_amount)}`);
+    }
+    // The Price model has no interval_count, so a quarterly price is
+    // unrepresentable — writing one yields a file that still fails the guard
+    // (review deleg_dd2f886e B&L-F4 / Design-F3). Refuse instead of repairing
+    // into a permanently red state.
+    if ((got.recurring?.interval_count ?? 1) !== 1) {
+      fail(
+        `cannot rewrite: ${key} bills every ${got.recurring.interval_count} ${got.recurring.interval}s ` +
+          '— the site renders a simple "per <interval>" and the Price type cannot express a count',
+      );
     }
     if (got.currency !== 'usd') {
       fail(`cannot rewrite: ${key} is ${JSON.stringify(got.currency)}, expected usd`);

--- a/scripts/check-prices.mjs
+++ b/scripts/check-prices.mjs
@@ -1,0 +1,180 @@
+#!/usr/bin/env node
+// Pricing guard, in two halves (JAR-660).
+//
+//   node scripts/check-prices.mjs           # always: no price literals in components
+//   STRIPE_API_KEY=rk_... node scripts/check-prices.mjs         # + reconcile with Stripe
+//   STRIPE_API_KEY=rk_... node scripts/check-prices.mjs --write # + rewrite pricing.ts
+//
+// Half one — no literals. Every dollar amount on this site renders from
+// src/app/data/pricing.ts. The page used to carry them inline, which is how it
+// advertised $24.95 for a Trip Pass we would never have charged, for weeks,
+// with nothing failing. This half always runs and needs no credential.
+//
+// Half two — Stripe agrees. A shared constant nobody verifies drifts exactly
+// as fast as a literal did, so the constants are reconciled against Stripe by
+// lookup_key. Needs a read-only key. Without one it says so loudly and skips,
+// rather than passing quietly and implying it checked.
+//
+// Fail closed: an unreadable file, an unparseable module or a Stripe error is
+// a failure, never a pass.
+
+import { readFileSync, writeFileSync, readdirSync, statSync } from 'node:fs';
+import { join, extname } from 'node:path';
+
+const ROOT = process.cwd();
+const PRICING_FILE = join(ROOT, 'src/app/data/pricing.ts');
+const COMPONENT_DIRS = ['src/app/pages', 'src/app/components', 'src/app'];
+const WRITE = process.argv.includes('--write');
+
+const fail = (msg) => {
+  console.error(`prices: ${msg}`);
+  process.exit(1);
+};
+
+// ── half one: no dollar literals outside the pricing module ─────────────────
+
+// $24.99, $99, $1,195.00 — any currency-shaped literal. Deliberately naive:
+// a false positive is a five-second conversation, a false negative is a wrong
+// price on the public site.
+const MONEY = /\$\s?\d[\d,]*(?:\.\d{2})?/g;
+
+function sourceFiles(dir) {
+  const out = [];
+  let entries;
+  try {
+    entries = readdirSync(join(ROOT, dir));
+  } catch {
+    return out; // directory does not exist in this checkout
+  }
+  for (const entry of entries) {
+    const rel = join(dir, entry);
+    const abs = join(ROOT, rel);
+    if (statSync(abs).isDirectory()) {
+      out.push(...sourceFiles(rel));
+    } else if (['.ts', '.tsx'].includes(extname(entry))) {
+      out.push(rel);
+    }
+  }
+  return out;
+}
+
+const scanned = new Set();
+const literalHits = [];
+
+for (const dir of COMPONENT_DIRS) {
+  for (const rel of sourceFiles(dir)) {
+    if (scanned.has(rel)) continue;
+    scanned.add(rel);
+    if (rel === 'src/app/data/pricing.ts') continue; // the one place amounts belong
+
+    const text = readFileSync(join(ROOT, rel), 'utf8');
+    text.split('\n').forEach((line, i) => {
+      // Comments explaining the history are allowed to name old prices.
+      const code = line.replace(/\/\/.*$/, '').replace(/\/\*.*?\*\//g, '');
+      for (const hit of code.match(MONEY) ?? []) {
+        literalHits.push(`${rel}:${i + 1}  ${hit}  ${line.trim().slice(0, 80)}`);
+      }
+    });
+  }
+}
+
+if (literalHits.length) {
+  console.error('prices: dollar amounts hardcoded outside src/app/data/pricing.ts\n');
+  for (const hit of literalHits) console.error(`  - ${hit}`);
+  console.error('\nRender them with priceOf(<lookup key>) instead. The site advertised');
+  console.error('$24.95 for a $24.99 Trip Pass because the number lived in a component.');
+  process.exit(1);
+}
+
+console.log(`prices: ok — no amount literals in ${scanned.size} component files`);
+
+// ── half two: the constants match Stripe ────────────────────────────────────
+
+const KEY = process.env.STRIPE_API_KEY;
+if (!KEY) {
+  console.log('prices: SKIPPED the Stripe reconciliation — STRIPE_API_KEY is not set.');
+  console.log('        Set a restricted, read-only key to verify the amounts really match.');
+  process.exit(0);
+}
+if (KEY.includes('_live_')) fail('refusing to run against a live key — use a restricted test key');
+
+let module_;
+try {
+  module_ = readFileSync(PRICING_FILE, 'utf8');
+} catch (err) {
+  fail(`cannot read ${PRICING_FILE}: ${err.message}`);
+}
+
+// Parse the generated block rather than importing TS from node.
+const BLOCK = /\/\/ BEGIN GENERATED PRICES[\s\S]*?\/\/ END GENERATED PRICES/;
+const block = module_.match(BLOCK);
+if (!block) fail('pricing.ts has no BEGIN/END GENERATED PRICES block to reconcile');
+
+const local = new Map();
+for (const m of block[0].matchAll(
+  /(\w+):\s*\{\s*lookupKey:\s*'([^']+)',\s*amountCents:\s*(\d+),\s*currency:\s*'([^']+)',\s*interval:\s*(null|'[^']+')/g,
+)) {
+  local.set(m[2], { amountCents: Number(m[3]), currency: m[4], interval: m[5].replace(/'/g, '') });
+}
+if (local.size === 0) fail('could not parse any prices out of pricing.ts');
+
+async function stripePrices() {
+  const res = await fetch('https://api.stripe.com/v1/prices?limit=100&active=true', {
+    headers: { Authorization: `Bearer ${KEY}` },
+  });
+  const body = await res.json();
+  if (!res.ok) fail(`Stripe error (${res.status}): ${body?.error?.message ?? 'unknown'}`);
+  return body.data ?? [];
+}
+
+const remote = new Map();
+for (const price of await stripePrices()) {
+  if (price.lookup_key) remote.set(price.lookup_key, price);
+}
+
+const mismatches = [];
+const money = (c) => `$${(c / 100).toFixed(2)}`;
+
+for (const [key, want] of local) {
+  const got = remote.get(key);
+  if (!got) {
+    mismatches.push(`${key}: no active Stripe price with that lookup_key`);
+    continue;
+  }
+  if (got.unit_amount !== want.amountCents) {
+    mismatches.push(`${key}: site says ${money(want.amountCents)}, Stripe says ${money(got.unit_amount)}`);
+  }
+  const gotInterval = got.recurring?.interval ?? null;
+  if (gotInterval !== (want.interval === 'null' ? null : want.interval)) {
+    mismatches.push(`${key}: site says interval ${want.interval}, Stripe says ${gotInterval}`);
+  }
+}
+
+if (WRITE) {
+  const lines = [...local.keys()].map((key) => {
+    const got = remote.get(key);
+    if (!got) fail(`cannot rewrite: Stripe has no active price with lookup_key ${key}`);
+    const interval = got.recurring?.interval ? `'${got.recurring.interval}'` : 'null';
+    return `  ${key}: { lookupKey: '${key}', amountCents: ${got.unit_amount}, currency: '${got.currency}', interval: ${interval} },`;
+  });
+  const rebuilt = [
+    '// BEGIN GENERATED PRICES — npm run sync:prices',
+    'export const PRICES: Record<PriceLookupKey, Price> = {',
+    ...lines,
+    '};',
+    '// END GENERATED PRICES',
+  ].join('\n');
+  writeFileSync(PRICING_FILE, module_.replace(BLOCK, rebuilt));
+  console.log(`prices: rewrote ${local.size} prices in pricing.ts from Stripe`);
+  process.exit(0);
+}
+
+if (mismatches.length) {
+  console.error('\nprices: the site and Stripe disagree\n');
+  for (const m of mismatches) console.error(`  - ${m}`);
+  console.error('\nStripe is the source of truth. Run `npm run sync:prices` to take its answer,');
+  console.error('or fix the price in Stripe if the site is what is right.');
+  process.exit(1);
+}
+
+console.log(`prices: ok — ${local.size} prices match Stripe`);

--- a/scripts/check-prices.mjs
+++ b/scripts/check-prices.mjs
@@ -90,6 +90,16 @@ console.log(`prices: ok — no amount literals in ${scanned.size} component file
 
 // ── half two: the constants match Stripe ────────────────────────────────────
 
+// The one Stripe account this catalogue belongs to. Same id in test and live
+// mode — the mode comes from which key you hand it — so pinning the account
+// survives the toggle that pinning price ids would not.
+//
+// This is not paranoia: a second account once held prices under the same
+// lookup keys at the same amounts, and nothing here could tell them apart,
+// because everything below resolves by lookup key (JAR-659). Right prices,
+// wrong Stripe, green check.
+const EXPECTED_ACCOUNT = 'acct_1ToBJsPDaNqc0Lek';
+
 const KEY = process.env.STRIPE_API_KEY;
 if (!KEY) {
   console.log('prices: SKIPPED the Stripe reconciliation — STRIPE_API_KEY is not set.');
@@ -118,6 +128,23 @@ for (const m of block[0].matchAll(
 }
 if (local.size === 0) fail('could not parse any prices out of pricing.ts');
 
+async function assertAccount() {
+  const res = await fetch('https://api.stripe.com/v1/account', {
+    headers: { Authorization: `Bearer ${KEY}` },
+  });
+  const body = await res.json();
+  if (!res.ok) {
+    // Not knowing which account we are reading is itself the failure.
+    fail(`cannot read /v1/account (${body?.error?.message ?? res.status}).\n` +
+      `       Add the "Account" read permission to this restricted key.\n` +
+      `       Without it this check cannot confirm it is reading ${EXPECTED_ACCOUNT}.`);
+  }
+  if (body.id !== EXPECTED_ACCOUNT) {
+    fail(`key belongs to ${body.id}, expected ${EXPECTED_ACCOUNT} — comparing against the wrong Stripe account`);
+  }
+  console.log(`prices: reading ${body.id} (${body.livemode ? 'LIVE' : 'test'} mode)`);
+}
+
 async function stripePrices() {
   const res = await fetch('https://api.stripe.com/v1/prices?limit=100&active=true', {
     headers: { Authorization: `Bearer ${KEY}` },
@@ -126,6 +153,8 @@ async function stripePrices() {
   if (!res.ok) fail(`Stripe error (${res.status}): ${body?.error?.message ?? 'unknown'}`);
   return body.data ?? [];
 }
+
+await assertAccount();
 
 const remote = new Map();
 for (const price of await stripePrices()) {

--- a/scripts/check-prices.mjs
+++ b/scripts/check-prices.mjs
@@ -282,11 +282,24 @@ async function assertAccount() {
   const res = await stripeFetch('/v1/account');
   const body = await res.json();
   if (!res.ok) {
+    const message = body?.error?.message ?? String(res.status);
+    // Stripe names the key's own account in the permission error, so when that
+    // account is ALREADY the wrong one, say both things now. Reporting only the
+    // missing permission sends the reader to the dashboard to grant it, and
+    // buys a second failing run that finally names the real problem — and CI
+    // round-trips here are minutes each.
+    const named = message.match(/account '(acct_[A-Za-z0-9]+)'/)?.[1];
+    const alsoWrongAccount = named && named !== EXPECTED_ACCOUNT
+      ? `\n\n       AND that key belongs to ${named}, not ${EXPECTED_ACCOUNT}.\n` +
+        `       The permission alone will not fix this. Issue a restricted, read-only\n` +
+        `       TEST key from ${EXPECTED_ACCOUNT} and replace the STRIPE_API_KEY secret.`
+      : '';
     // Not knowing which account we are reading is itself the failure.
-    fail(`cannot read /v1/account (${body?.error?.message ?? res.status}).\n` +
+    fail(`cannot read /v1/account (${message}).\n` +
       `       Add the "Basic Business Contact Information Read" permission\n` +
       `       (accounts_kyc_basic_read) to this restricted key.\n` +
-      `       Without it this check cannot confirm it is reading ${EXPECTED_ACCOUNT}.`);
+      `       Without it this check cannot confirm it is reading ${EXPECTED_ACCOUNT}.` +
+      alsoWrongAccount);
   }
   if (body.id !== EXPECTED_ACCOUNT) {
     fail(`key belongs to ${body.id}, expected ${EXPECTED_ACCOUNT} — comparing against the wrong Stripe account`);

--- a/scripts/check-prices.mjs
+++ b/scripts/check-prices.mjs
@@ -240,6 +240,11 @@ for (const [key, want] of local) {
   if (got.unit_amount !== want.amountCents) {
     mismatches.push(`${key}: site says ${money(want.amountCents)}, Stripe says ${money(got.unit_amount)}`);
   }
+  // interval_count, not just interval: a quarterly price is interval=month
+  // with count=3, and the page would render it as "per month" (L2).
+  if ((got.recurring?.interval_count ?? 1) !== 1) {
+    mismatches.push(`${key}: Stripe bills every ${got.recurring.interval_count} ${got.recurring.interval}s — the site renders a simple "per ${got.recurring.interval}"`);
+  }
   const gotInterval = got.recurring?.interval ?? null;
   if (gotInterval !== (want.interval === 'null' ? null : want.interval)) {
     mismatches.push(`${key}: site says interval ${want.interval}, Stripe says ${gotInterval}`);

--- a/scripts/check-prices.mjs
+++ b/scripts/check-prices.mjs
@@ -126,15 +126,18 @@ console.log(`prices: ok — no amount literals in ${scanned.size} component file
 
 // ── half two: the constants match Stripe ────────────────────────────────────
 
-// The one Stripe account this catalogue belongs to. Same id in test and live
-// mode — the mode comes from which key you hand it — so pinning the account
-// survives the toggle that pinning price ids would not.
+// The one Stripe account this catalogue belongs to: the org's JarvisTravel
+// sandbox, decided on JAR-660 (2026-08-09) after the catalogue was found
+// stranded in a personal account the org cannot see or manage. A sandbox is
+// its own account id, so at live launch the catalogue is minted in the org's
+// live account and this pin moves in that same deliberate act — this guard
+// fails loudly if the edit is forgotten.
 //
 // This is not paranoia: a second account once held prices under the same
 // lookup keys at the same amounts, and nothing here could tell them apart,
 // because everything below resolves by lookup key (JAR-659). Right prices,
 // wrong Stripe, green check.
-const EXPECTED_ACCOUNT = 'acct_1ToBJsPDaNqc0Lek';
+const EXPECTED_ACCOUNT = 'acct_1ToBK0ABsvYNMJZ0';
 
 // The three keys this catalogue is defined as having. Asserted as an exact set
 // below, so a key *deleted* from pricing.ts fails here rather than at runtime
@@ -166,10 +169,12 @@ if (!KEY) {
 if (KEY.includes('_live_') && WRITE) {
   fail('refusing to write from a live key — use a restricted test key');
 }
-// Check-only mode may use a live restricted key: the account pin survives the
-// test→live toggle (same acct id), and launch-time catalogue verification is
-// exactly what the guard is for (review deleg_dd2f886e F1). Writing is still
-// banned — regenerate only from test.
+// Check-only mode still accepts a live restricted key, but while the pin
+// names the sandbox, a live key fails the account assert below — correctly:
+// there is no live catalogue yet. Launch mints one in the org's live account
+// and moves EXPECTED_ACCOUNT, and from then on live check-only verification
+// works as designed (review deleg_dd2f886e F1). Writing is still banned —
+// regenerate only from test.
 
 let module_;
 try {

--- a/src/app/data/pricing.ts
+++ b/src/app/data/pricing.ts
@@ -25,16 +25,16 @@
 export type PriceLookupKey = 'jt_trip_pass' | 'jt_explore_annual' | 'jt_explore_monthly';
 
 export interface Price {
-  lookupKey: PriceLookupKey;
+  readonly lookupKey: PriceLookupKey;
   /** Minor units, exactly as Stripe stores them. */
-  amountCents: number;
-  currency: 'usd';
+  readonly amountCents: number;
+  readonly currency: 'usd';
   /** Billing period, or null for a one-time purchase. */
-  interval: 'month' | 'year' | null;
+  readonly interval: 'month' | 'year' | null;
 }
 
 // BEGIN GENERATED PRICES — npm run sync:prices
-export const PRICES: Record<PriceLookupKey, Price> = {
+export const PRICES: Readonly<Record<PriceLookupKey, Price>> = {
   jt_trip_pass: { lookupKey: 'jt_trip_pass', amountCents: 2499, currency: 'usd', interval: null },
   jt_explore_annual: { lookupKey: 'jt_explore_annual', amountCents: 9900, currency: 'usd', interval: 'year' },
   jt_explore_monthly: { lookupKey: 'jt_explore_monthly', amountCents: 1195, currency: 'usd', interval: 'month' },

--- a/src/app/data/pricing.ts
+++ b/src/app/data/pricing.ts
@@ -1,13 +1,16 @@
 // ============================================================================
 // PRICING — the only place on this site that knows what anything costs.
 //
-// Amounts live in Stripe, in account acct_1ToBJsPDaNqc0Lek — test mode today,
-// the same account in live mode at launch. This file mirrors them, keyed by the
+// Amounts live in Stripe, in the org's JarvisTravel sandbox
+// acct_1ToBK0ABsvYNMJZ0 (JAR-660 decision, 2026-08-09). At launch the live
+// catalogue is minted in the org's live account with the same lookup keys, and
+// the account pins here and in check-prices.mjs move with it. This file
+// mirrors Stripe, keyed by the
 // same lookup_key the backend resolves at checkout (core: config/stripe/setup.js,
 // migration 063, JAR-658/659). A lookup key is a stable handle: Stripe Prices
 // are immutable, so a price change mints a new Price and the key transfers to
-// it — and it is per-mode, so the live catalogue must be created with the same
-// keys before the toggle.
+// it — and it is per-account-and-mode, so the live catalogue must exist before
+// the toggle.
 //
 // Regenerate rather than hand-edit:
 //

--- a/src/app/data/pricing.ts
+++ b/src/app/data/pricing.ts
@@ -60,3 +60,21 @@ export function priceOf(key: PriceLookupKey): string {
   const price = PRICES[key];
   return formatPrice(price.amountCents, price.currency);
 }
+
+/** What paying annually saves against paying monthly, as a whole percent, or
+ *  null when the comparison cannot honestly be made.
+ *
+ *  Replaces a hardcoded "Best value" badge. That claim is only true relative to
+ *  something, and stating it without the number invites the reader to wonder
+ *  what it beats. Derived from PRICES — which is the generated block, synced
+ *  from Stripe — so the figure cannot drift from the amounts rendered beside it.
+ *
+ *  Returns null rather than guessing when annual is not actually cheaper, which
+ *  keeps the badge honest if the catalogue ever changes shape. */
+export function annualSavingPercent(): number | null {
+  const year = PRICES.jt_explore_annual.amountCents;
+  const month = PRICES.jt_explore_monthly.amountCents;
+  if (!Number.isFinite(year) || !Number.isFinite(month) || month <= 0) return null;
+  const pct = Math.round((1 - year / (month * 12)) * 100);
+  return pct > 0 ? pct : null;
+}

--- a/src/app/data/pricing.ts
+++ b/src/app/data/pricing.ts
@@ -1,0 +1,59 @@
+// ============================================================================
+// PRICING — the only place on this site that knows what anything costs.
+//
+// Amounts live in Stripe. This file mirrors them, keyed by the same lookup_key
+// the backend resolves at checkout (core: config/stripe/setup.js, migration
+// 063, JAR-658/659). A lookup key is a stable handle: Stripe Prices are
+// immutable, so a price change mints a new Price and the key transfers to it.
+//
+// Regenerate rather than hand-edit:
+//
+//   STRIPE_API_KEY=rk_test_... npm run sync:prices        # rewrite from Stripe
+//   STRIPE_API_KEY=rk_test_... npm run lint:prices        # verify, change nothing
+//
+// The literals used to sit in PricingPage.tsx, where the site advertised
+// $24.95 for a Trip Pass we would never have charged — for weeks, found by
+// hand (JAR-660). Two guards stop that recurring: lint:prices fails when this
+// file and Stripe disagree, and check-prices.mjs fails when a dollar amount
+// reappears as a literal in a component.
+// ============================================================================
+
+/** Stable Stripe lookup keys. Shared contract with core — do not rename. */
+export type PriceLookupKey = 'jt_trip_pass' | 'jt_explore_annual' | 'jt_explore_monthly';
+
+export interface Price {
+  lookupKey: PriceLookupKey;
+  /** Minor units, exactly as Stripe stores them. */
+  amountCents: number;
+  currency: 'usd';
+  /** Billing period, or null for a one-time purchase. */
+  interval: 'month' | 'year' | null;
+}
+
+// BEGIN GENERATED PRICES — npm run sync:prices
+export const PRICES: Record<PriceLookupKey, Price> = {
+  jt_trip_pass: { lookupKey: 'jt_trip_pass', amountCents: 2499, currency: 'usd', interval: null },
+  jt_explore_annual: { lookupKey: 'jt_explore_annual', amountCents: 9900, currency: 'usd', interval: 'year' },
+  jt_explore_monthly: { lookupKey: 'jt_explore_monthly', amountCents: 1195, currency: 'usd', interval: 'month' },
+};
+// END GENERATED PRICES
+
+/**
+ * Format an amount the way the page shows it: no trailing ".00", because
+ * "$99" reads as a price and "$99.00" reads as an invoice.
+ */
+export function formatPrice(cents: number, currency: string = 'usd'): string {
+  const whole = cents % 100 === 0;
+  return new Intl.NumberFormat('en-US', {
+    style: 'currency',
+    currency: currency.toUpperCase(),
+    minimumFractionDigits: whole ? 0 : 2,
+    maximumFractionDigits: whole ? 0 : 2,
+  }).format(cents / 100);
+}
+
+/** The display amount for a plan, e.g. "$24.99" or "$99". */
+export function priceOf(key: PriceLookupKey): string {
+  const price = PRICES[key];
+  return formatPrice(price.amountCents, price.currency);
+}

--- a/src/app/data/pricing.ts
+++ b/src/app/data/pricing.ts
@@ -1,10 +1,13 @@
 // ============================================================================
 // PRICING — the only place on this site that knows what anything costs.
 //
-// Amounts live in Stripe. This file mirrors them, keyed by the same lookup_key
-// the backend resolves at checkout (core: config/stripe/setup.js, migration
-// 063, JAR-658/659). A lookup key is a stable handle: Stripe Prices are
-// immutable, so a price change mints a new Price and the key transfers to it.
+// Amounts live in Stripe, in account acct_1ToBJsPDaNqc0Lek — test mode today,
+// the same account in live mode at launch. This file mirrors them, keyed by the
+// same lookup_key the backend resolves at checkout (core: config/stripe/setup.js,
+// migration 063, JAR-658/659). A lookup key is a stable handle: Stripe Prices
+// are immutable, so a price change mints a new Price and the key transfers to
+// it — and it is per-mode, so the live catalogue must be created with the same
+// keys before the toggle.
 //
 // Regenerate rather than hand-edit:
 //

--- a/src/app/data/pricing.ts
+++ b/src/app/data/pricing.ts
@@ -61,6 +61,17 @@ export function priceOf(key: PriceLookupKey): string {
   return formatPrice(price.amountCents, price.currency);
 }
 
+/**
+ * The billing period rendered next to an amount, derived from the interval
+ * Stripe verifies — "per year", "per month", or "per trip" for a one-time
+ * purchase. Deriving kills the parallel "per" namespace: a cadence whose
+ * rendered period disagreed with its interval used to compile cleanly and
+ * pass every guard while showing "$99 per month" (review deleg_dd2f886e).
+ */
+export function periodOf(key: PriceLookupKey): string {
+  return PRICES[key].interval ?? 'trip';
+}
+
 /** What paying annually saves against paying monthly, as a whole percent, or
  *  null when the comparison cannot honestly be made.
  *

--- a/src/app/pages/PricingPage.tsx
+++ b/src/app/pages/PricingPage.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import { Check } from 'lucide-react';
 import { Link } from 'react-router-dom';
-import { priceOf } from '../data/pricing';
+import { priceOf, type PriceLookupKey } from '../data/pricing';
 
 // Approved offer structure (pricing handoff, 2026-07): exactly two offers.
 // Trip Pass is a real single-trip product, not a trial. Explore is the hero
@@ -34,17 +34,23 @@ type CadenceKey = 'annual' | 'monthly';
 interface Cadence {
   key: CadenceKey;
   label: string;
-  amount: string;
+  // The Stripe lookup key, not a rendered string. Carrying a pre-formatted
+  // amount meant CadenceKey and PriceLookupKey were parallel namespaces with
+  // nothing tying them together, so a new cadence pointing at the wrong key
+  // would compile cleanly and render a wrong price — the exact failure this
+  // ticket exists to kill, one level up (core#36 review, M4). Typed this way,
+  // a mismatch is a compile error.
+  lookupKey: PriceLookupKey;
   per: string;
   best?: boolean;
 }
 
-// Cadences of ONE subscription, not separate tiers. The amounts come from
+// Cadences of ONE subscription, not separate tiers. Amounts come from
 // src/app/data/pricing.ts, which mirrors Stripe by lookup key — a price change
 // there reaches this page with no edit here (JAR-660).
 const CADENCES: Cadence[] = [
-  { key: 'annual', label: 'Annual', amount: priceOf('jt_explore_annual'), per: 'year', best: true },
-  { key: 'monthly', label: 'Monthly', amount: priceOf('jt_explore_monthly'), per: 'month' },
+  { key: 'annual', label: 'Annual', lookupKey: 'jt_explore_annual', per: 'year', best: true },
+  { key: 'monthly', label: 'Monthly', lookupKey: 'jt_explore_monthly', per: 'month' },
 ];
 
 // The two visual states a card can be in. Both keep a 1px border so nothing
@@ -231,7 +237,7 @@ export function PricingPage() {
                           exploreHot ? 'text-sky-100' : 'text-gray-600'
                         }`}
                       >
-                        {option.amount}
+                        {priceOf(option.lookupKey)}
                         <span
                           className={`transition-colors ${
                             exploreHot ? 'text-sky-200' : 'text-gray-500'
@@ -251,7 +257,7 @@ export function PricingPage() {
                     exploreHot ? 'text-gray-50' : 'text-gray-900'
                   }`}
                 >
-                  {cadence.amount}
+                  {priceOf(cadence.lookupKey)}
                 </span>
                 <span
                   className={`ml-2 transition-colors ${

--- a/src/app/pages/PricingPage.tsx
+++ b/src/app/pages/PricingPage.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import { Check } from 'lucide-react';
 import { Link } from 'react-router-dom';
-import { priceOf, annualSavingPercent, type PriceLookupKey } from '../data/pricing';
+import { priceOf, periodOf, annualSavingPercent, type PriceLookupKey } from '../data/pricing';
 
 // Approved offer structure (pricing handoff, 2026-07): exactly two offers.
 // Trip Pass is a real single-trip product, not a trial. Explore is the hero
@@ -31,8 +31,8 @@ const EXPLORE_POINTS = [
   'Full subscription access',
   'Best choice for travelers planning more than one trip',
   SAVING_PCT !== null
-    ? `Explore Annual is ${priceOf('jt_explore_annual')} per year, ${SAVING_PCT}% less than paying monthly`
-    : `Explore Annual is ${priceOf('jt_explore_annual')} per year`,
+    ? `Explore Annual is ${priceOf('jt_explore_annual')} per ${periodOf('jt_explore_annual')}, ${SAVING_PCT}% less than paying monthly`
+    : `Explore Annual is ${priceOf('jt_explore_annual')} per ${periodOf('jt_explore_annual')}`,
 ];
 
 type CadenceKey = 'annual' | 'monthly';
@@ -47,16 +47,17 @@ interface Cadence {
   // ticket exists to kill, one level up (core#36 review, M4). Typed this way,
   // a mismatch is a compile error.
   lookupKey: PriceLookupKey;
-  per: string;
   best?: boolean;
 }
 
 // Cadences of ONE subscription, not separate tiers. Amounts come from
 // src/app/data/pricing.ts, which mirrors Stripe by lookup key — a price change
-// there reaches this page with no edit here (JAR-660).
+// there reaches this page with no edit here (JAR-660). The rendered period
+// ("per year"/"per month") is derived from the interval via periodOf(), never
+// a parallel string (review deleg_dd2f886e).
 const CADENCES: Cadence[] = [
-  { key: 'annual', label: 'Annual', lookupKey: 'jt_explore_annual', per: 'year', best: true },
-  { key: 'monthly', label: 'Monthly', lookupKey: 'jt_explore_monthly', per: 'month' },
+  { key: 'annual', label: 'Annual', lookupKey: 'jt_explore_annual', best: true },
+  { key: 'monthly', label: 'Monthly', lookupKey: 'jt_explore_monthly' },
 ];
 
 // The two visual states a card can be in. Both keep a 1px border so nothing
@@ -249,7 +250,7 @@ export function PricingPage() {
                             exploreHot ? 'text-sky-200' : 'text-gray-500'
                           }`}
                         >
-                          /{option.per}
+                          /{periodOf(option.lookupKey)}
                         </span>
                       </span>
                     </button>
@@ -270,7 +271,7 @@ export function PricingPage() {
                     exploreHot ? 'text-sky-200' : 'text-gray-500'
                   }`}
                 >
-                  per {cadence.per}
+                  per {periodOf(cadence.lookupKey)}
                 </span>
               </div>
 

--- a/src/app/pages/PricingPage.tsx
+++ b/src/app/pages/PricingPage.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import { Check } from 'lucide-react';
 import { Link } from 'react-router-dom';
-import { priceOf, type PriceLookupKey } from '../data/pricing';
+import { priceOf, annualSavingPercent, type PriceLookupKey } from '../data/pricing';
 
 // Approved offer structure (pricing handoff, 2026-07): exactly two offers.
 // Trip Pass is a real single-trip product, not a trial. Explore is the hero
@@ -23,10 +23,16 @@ const TRIP_PASS_POINTS = [
   'Good for travelers who have one trip in mind right now',
 ];
 
+// Derived from the generated PRICES block, so the badge and this bullet can
+// never disagree with the amounts rendered beside them.
+const SAVING_PCT = annualSavingPercent();
+
 const EXPLORE_POINTS = [
   'Full subscription access',
   'Best choice for travelers planning more than one trip',
-  `Explore Annual is the best value at ${priceOf('jt_explore_annual')} per year`,
+  SAVING_PCT !== null
+    ? `Explore Annual is ${priceOf('jt_explore_annual')} per year, ${SAVING_PCT}% less than paying monthly`
+    : `Explore Annual is ${priceOf('jt_explore_annual')} per year`,
 ];
 
 type CadenceKey = 'annual' | 'monthly';
@@ -222,13 +228,13 @@ export function PricingPage() {
                         >
                           {option.label}
                         </span>
-                        {option.best && (
+                        {option.best && SAVING_PCT !== null && (
                           <span
                             className={`text-[11px] font-semibold tracking-wide uppercase bg-amber-400/[0.12] border border-amber-400/30 px-2 py-0.5 rounded-full transition-colors ${
                               exploreHot ? 'text-amber-400' : 'text-amber-700'
                             }`}
                           >
-                            Best value
+                            Save {SAVING_PCT}%
                           </span>
                         )}
                       </span>

--- a/src/app/pages/PricingPage.tsx
+++ b/src/app/pages/PricingPage.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { Check } from 'lucide-react';
 import { Link } from 'react-router-dom';
+import { priceOf } from '../data/pricing';
 
 // Approved offer structure (pricing handoff, 2026-07): exactly two offers.
 // Trip Pass is a real single-trip product, not a trial. Explore is the hero
@@ -25,7 +26,7 @@ const TRIP_PASS_POINTS = [
 const EXPLORE_POINTS = [
   'Full subscription access',
   'Best choice for travelers planning more than one trip',
-  'Explore Annual is the best value at $99 per year',
+  `Explore Annual is the best value at ${priceOf('jt_explore_annual')} per year`,
 ];
 
 type CadenceKey = 'annual' | 'monthly';
@@ -38,11 +39,12 @@ interface Cadence {
   best?: boolean;
 }
 
-// Single source of truth for Explore pricing - rows and the summary price
-// both render from here.
+// Cadences of ONE subscription, not separate tiers. The amounts come from
+// src/app/data/pricing.ts, which mirrors Stripe by lookup key — a price change
+// there reaches this page with no edit here (JAR-660).
 const CADENCES: Cadence[] = [
-  { key: 'annual', label: 'Annual', amount: '$99', per: 'year', best: true },
-  { key: 'monthly', label: 'Monthly', amount: '$11.95', per: 'month' },
+  { key: 'annual', label: 'Annual', amount: priceOf('jt_explore_annual'), per: 'year', best: true },
+  { key: 'monthly', label: 'Monthly', amount: priceOf('jt_explore_monthly'), per: 'month' },
 ];
 
 // The two visual states a card can be in. Both keep a 1px border so nothing
@@ -103,7 +105,7 @@ export function PricingPage() {
                     tripActive ? 'text-gray-50' : 'text-gray-900'
                   }`}
                 >
-                  $24.99
+                  {priceOf('jt_trip_pass')}
                 </span>
                 <span
                   className={`ml-2 transition-colors ${
@@ -143,7 +145,7 @@ export function PricingPage() {
               {/* Routes to the interest form until the app/payment flow is live. */}
               <Link
                 to="/contact"
-                className={`mt-auto self-start px-8 py-3.5 rounded-sm font-semibold border transition-colors text-gray-900 ${
+                className={`mt-auto self-start px-8 py-3.5 rounded-full font-semibold border transition-colors text-gray-900 ${
                   tripActive
                     ? 'bg-amber-400 border-amber-400 hover:bg-amber-300 hover:border-amber-300'
                     : 'bg-transparent border-gray-300'
@@ -216,7 +218,7 @@ export function PricingPage() {
                         </span>
                         {option.best && (
                           <span
-                            className={`text-[11px] font-semibold tracking-wide uppercase bg-amber-400/[0.12] border border-amber-400/30 px-2 py-0.5 rounded-sm transition-colors ${
+                            className={`text-[11px] font-semibold tracking-wide uppercase bg-amber-400/[0.12] border border-amber-400/30 px-2 py-0.5 rounded-full transition-colors ${
                               exploreHot ? 'text-amber-400' : 'text-amber-700'
                             }`}
                           >
@@ -284,7 +286,7 @@ export function PricingPage() {
               {/* Routes to the interest form until the app/payment flow is live. */}
               <Link
                 to="/contact"
-                className={`mt-auto w-full py-3.5 rounded-sm font-semibold text-center border transition-colors text-gray-900 ${
+                className={`mt-auto w-full py-3.5 rounded-full font-semibold text-center border transition-colors text-gray-900 ${
                   exploreHot
                     ? 'bg-amber-400 border-amber-400 hover:bg-amber-300 hover:border-amber-300'
                     : 'bg-transparent border-gray-300'


### PR DESCRIPTION
## What

Amounts move out of `PricingPage.tsx` into `src/app/data/pricing.ts`, keyed by the same Stripe `lookup_key` the backend resolves at checkout. The page renders through `priceOf()`. Two guards keep it honest.

## Why

[JAR-660](https://linear.app/ryan-pearson/issue/JAR-660). Every price was a string literal, and it had already drifted: the site advertised **$24.95** for a Trip Pass we would never have charged, for weeks, with no test on the page and no link to the real prices. It was found by hand during an unrelated audit.

The decided catalogue — Trip Pass $24.99, Explore+ $99.00/yr, Explore+ $11.95/mo — is now in exactly two places that are checked against each other: Stripe, and this file.

## The guards

```bash
npm run lint:prices    # literal scan (always) + Stripe reconciliation (with a key)
npm run sync:prices    # rewrite the generated block from Stripe
```

**Half one — no literals.** Scans every component for a currency-shaped literal. Always runs, needs no credential. This is the half that directly prevents the $24.95 class: reverting the Trip Pass amount to a literal fails with the file, line and value.

**Half two — Stripe agrees.** Reconciles the constants against Stripe by `lookup_key`, comparing amount *and* interval. Without `STRIPE_API_KEY` it prints a SKIPPED line and exits 0 — loudly not-checking beats quietly passing. Wired into `pr-checks.yml` reading `secrets.STRIPE_API_KEY`; it starts enforcing the moment that secret exists.

**No runtime fetch, deliberately** — the ticket is right that a pricing page which can fail to render prices because an API is slow is worse than the problem. The build never talks to Stripe; only the guard does.

## How to verify

```bash
npm run lint:prices
npm run build
```

Checked in the browser against the dev server: Trip Pass **$24.99**, Annual **$99/year**, Monthly **$11.95/month**, the bullet line reading "$99 per year", and the cadence toggle switching the summary to "$11.95 per month". No console errors. `tsc --noEmit` clean, ESLint 0.

Formatting is deliberate: `$99`, not `$99.00`. A whole-dollar amount reads as a price; two zeroes read as an invoice.

## Interaction with #33

[#33](https://github.com/jarvis-travel/marketing-website/pull/33) corrects that same literal from $24.95 to $24.99 and is correct. This PR deletes the literal outright, so whichever lands second makes the other moot — merge #33 first if you want the fix on main sooner, or close it in favour of this. Branched from `main` rather than stacking on it.

## Not in scope

The app-side half is [core#277](https://github.com/jarvis-travel/core/pull/277) (JAR-659): checkout now resolves the Price from Stripe by the same lookup keys, and `seed.sql` no longer defines a third catalogue at $4.99.

Closes JAR-660