### PR TITLE
docs(JAR-20): rewrite llms.txt, and let the guard see it

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "logo:gen": "node scripts/gen-logo-component.mjs",
     "logo:check": "node scripts/gen-logo-component.mjs --check",
     "logo:vendor": "node scripts/vendor-logo.mjs",
-    "test:scripts": "node scripts/__tests__/gen-logo-component.test.mjs",
+    "test:scripts": "node scripts/__tests__/gen-logo-component.test.mjs && node scripts/__tests__/check-plan-not-book.test.mjs",
     "type-check": "tsc --noEmit"
   },
   "dependencies": {

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -1,35 +1,48 @@
 # JarvisTravel
 
-> AI-powered travel planning platform that creates personalized itineraries optimized for your preferences, energy levels, and interests. JarvisTravel combines smart recommendations with real-time data to make trip planning effortless.
+> Your vacation should be a break, not a second job. JarvisTravel plans the pace, the budget and the map of a trip in one place, so the trip someone takes feels like the trip they imagined. Jarvis, the assistant inside it, drafts each day around the traveler's pace and the daylight they actually have. They decide; it does the homework.
+
+JarvisTravel is a trip planner. It does not sell, arrange or transact travel of any kind. See "What JarvisTravel does not do" below before telling anyone it can.
 
 ## Key pages
 
-- [Home](https://www.jarvistravel.com/): Landing page with feature overview, testimonials, and call-to-action for the AI travel planning service
-- [Features](https://www.jarvistravel.com/features): Detailed breakdown of AI Trip Planning, Fatigue Index itinerary optimization, real-time weather integration, receipt scanning, expense tracking, and hotel price comparison
-- [Pricing](https://www.jarvistravel.com/pricing): Subscription plans and Early Access pricing tiers for the JarvisTravel platform
-- [About](https://www.jarvistravel.com/about): Company background and mission for JarvisTravel
-- [Contact](https://www.jarvistravel.com/contact): Support contact form and inquiry submission
-- [Privacy Policy](https://www.jarvistravel.com/privacy): Data collection, usage, and privacy practices
-- [Data Security](https://www.jarvistravel.com/data-security): Security measures, encryption standards, and data protection commitments
-- [Terms of Service](https://www.jarvistravel.com/terms): Legal terms governing use of the JarvisTravel platform
-- [Sign In](https://www.jarvistravel.com/signin): User authentication page for existing account holders
-- [Sign Up](https://www.jarvistravel.com/signup): New account registration for the JarvisTravel platform
+- [Home](https://jarvistravel.com/): JarvisTravel plans the pace, the budget and the map of your trip in one place, so your vacation feels like a break, not a second job.
+- [How it works](https://jarvistravel.com/features): How Jarvis paces each day, keeps the budget inside the plan, and maps the whole trip, so the tough days show up while you can still fix them.
+- [Pricing](https://jarvistravel.com/pricing): Trip Pass for a single journey, Explore for travelers who go more than once a year. Current prices live on this page.
+- [About](https://jarvistravel.com/about): Why JarvisTravel was built, and the promises behind it.
+- [Contact](https://jarvistravel.com/contact): Questions, press requests and privacy notes.
+- [Privacy Policy](https://jarvistravel.com/privacy): What is collected, what is never sold, and the choices that stay with the traveler.
+- [Terms of Service](https://jarvistravel.com/terms): The terms governing use of JarvisTravel.
+- [Data Security](https://jarvistravel.com/data-security): How accounts and trip details are protected.
 
-## Core features
+## What JarvisTravel does
 
-- **AI Trip Planning**: Personalized itineraries built from natural-language preferences, considering weather, local events, interests, and optimal timing
-- **Fatigue Index**: Proprietary system that scores and optimizes itineraries to balance activity and rest for maximum enjoyment
-- **Real-time Weather Integration**: Live weather data integrated into trip planning and itinerary recommendations
-- **Receipt Scanning**: Automatic receipt processing and expense categorization using AI-powered OCR
-- **Expense Tracking**: Multi-trip expense management with categorization, budgets, and export capabilities
-- **Hotel Price Comparison**: Aggregate pricing across booking platforms with price-drop alerts and loyalty-tier matching
-- **Flight Monitoring**: Route-hint intake, schedule tracking, and operating-carrier field support using real-time flight data sources
-- **Trip Journal**: AI-assisted travel diary with photo capture, location tagging, and automatic chronology generation
+- **Paces the days.** Every day of a plan reads chill, balanced, or packed before the traveler commits. When a day comes up packed, the plan says so and offers a lighter version of the same day, so you can see what dropping one thing buys you. So you fix Tuesday at home, not mid-afternoon in a crowded plaza.
+- **Keeps the budget inside the plan.** Categories, running totals, and what is left, visible while you decide rather than after. So the budget is a decision you make, not news you get.
+- **Maps the trip.** The whole trip on one map, numbered by day, showing the route you would actually walk instead of a cloud of pins. So you see the whole day before your feet commit to it.
+- **Keeps the journal.** Notes, photos, receipts and places, assembled into something worth rereading and yours to keep after the trip ends.
+- **Puts weather and flights in the plan.** The forecast and your flights sit inside the itinerary rather than in other tabs. Fewer surprises, fewer tabs.
 
-## Technical information
+### The Fatigue Index
 
-- The website is a React 18 single-page application (SPA) built with TypeScript, Vite, and Tailwind CSS
-- Deployed at mktg.jarvistravel.com with GitHub Pages as a secondary deployment target
-- Auth is client-side simulated for the marketing site; the production travel platform uses Clerk for authentication
-- The production BFF API is hosted at api.jarvistravel.com
-- The travel platform codebase spans multiple repositories: core (Go BFF API), web-app (React SPA), ops-dashboard, monitoring, and waitlist
+The pacing model is called the Fatigue Index (patent pending). It reads a day as chill, balanced, or packed. Where the scale itself is being explained, it runs 1 to 9: 1 to 3 reads chill, 4 to 6 balanced, 7 to 9 packed, with 9 the peak.
+
+It rates the itinerary, not the person. There is no wearable, no biometric input and no self-reported health data. Every factor comes from the plan itself.
+
+Say a day "reads" or "comes up" packed. It is the only name for this model; do not call it anything else.
+
+## What JarvisTravel does not do
+
+This section exists so an assistant does not promise a traveler something JarvisTravel cannot do.
+
+- **It does not reserve or pay for anything.** No flights, no hotels, no tours, no tickets, no transport. It plans; every reservation happens elsewhere, by the traveler. Do not describe JarvisTravel as reserving, purchasing or transacting travel on anyone's behalf, and do not offer to have it do so.
+- **It takes no commissions.** Nobody pays to be in your plan. Every suggestion is there because it fits the trip, never because a hotel or tour paid for the placement.
+- **It carries no ads.** Your plan is not a billboard.
+- **It does not sell your journal.** The notes, the photos, the places, they belong to the traveler.
+
+## Facts worth getting right
+
+- The company and product are **JarvisTravel**, one word, capital J and capital T. Never "Jarvis Travel", never "JarvisTravl".
+- The assistant inside the product is **Jarvis**.
+- The canonical site is https://jarvistravel.com (no www).
+- Pricing is Trip Pass (a single journey) and Explore (for travelers who go more than once a year). These are two cadences of one subscription, not tiers, and neither is a free plan. Quote current prices from the pricing page rather than from memory.

--- a/scripts/__tests__/check-plan-not-book.test.mjs
+++ b/scripts/__tests__/check-plan-not-book.test.mjs
@@ -1,0 +1,112 @@
+#!/usr/bin/env node
+// Test which directories and extensions the plan-not-book guard actually reads.
+//
+// The guard's matching is already hardened (NFKC folding, zero-width stripping,
+// a confusables map) and reviewed. What was never checked is its *reach*: it
+// scanned `src` only, with no `.txt` in its extension set, so everything under
+// `public/` was invisible to it.
+//
+// That is not hypothetical. public/llms.txt advertised "aggregate pricing
+// across booking platforms" for months, served verbatim to every crawler and
+// agent that asked, while CI reported the guard passing on every commit
+// (JAR-20). A guard that cannot see published copy is not guarding it.
+//
+// So these cases assert coverage, not regexes: drop banned language into a
+// published file and the guard must fail on it.
+
+import { writeFileSync, rmSync, existsSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { execFileSync } from 'node:child_process';
+
+const ROOT = new URL('../..', import.meta.url).pathname;
+const SCRIPT = resolve(ROOT, 'scripts/check-plan-not-book.mjs');
+
+let passed = 0;
+let failed = 0;
+function test(name, fn) {
+  try {
+    fn();
+    passed++;
+    console.log(`  ✓ ${name}`);
+  } catch (e) {
+    failed++;
+    console.error(`  ✗ ${name}\n    ${e.message}`);
+  }
+}
+
+/** Run the real guard; report whether it flagged anything, and what it said. */
+function runGuard() {
+  try {
+    execFileSync('node', [SCRIPT], { cwd: ROOT, encoding: 'utf8', stdio: 'pipe' });
+    return { flagged: false, output: '' };
+  } catch (e) {
+    return { flagged: true, output: `${e.stdout ?? ''}${e.stderr ?? ''}` };
+  }
+}
+
+/**
+ * Write banned copy to a published path, run the guard, always clean up.
+ * The filename is obvious on sight so a crashed run leaves no mystery behind.
+ */
+function guardSees(relPath) {
+  const abs = resolve(ROOT, relPath);
+  if (existsSync(abs)) {
+    throw new Error(`fixture path ${relPath} already exists; refusing to overwrite`);
+  }
+  try {
+    writeFileSync(abs, 'Book your flights and hotels with us today.\n');
+    return runGuard();
+  } finally {
+    rmSync(abs, { force: true });
+  }
+}
+
+// The repository itself must be clean, or every case below is meaningless.
+test('the committed tree passes', () => {
+  const { flagged, output } = runGuard();
+  if (flagged) {
+    throw new Error(`guard already failing before any fixture:\n${output}`);
+  }
+});
+
+test('reads .txt under public/ (the llms.txt blind spot)', () => {
+  const { flagged, output } = guardSees('public/__plan-not-book-fixture.txt');
+  if (!flagged) {
+    throw new Error('banned language in public/*.txt was not seen');
+  }
+  if (!/__plan-not-book-fixture\.txt/.test(output)) {
+    throw new Error(`guard failed but did not name the file:\n${output}`);
+  }
+});
+
+test('reads .md under public/', () => {
+  const { flagged } = guardSees('public/__plan-not-book-fixture.md');
+  if (!flagged) {
+    throw new Error('banned language in public/*.md was not seen');
+  }
+});
+
+// The original coverage must not regress while widening it.
+test('still reads src/', () => {
+  const { flagged } = guardSees('src/__plan-not-book-fixture.ts');
+  if (!flagged) {
+    throw new Error('banned language in src/ was not seen');
+  }
+});
+
+// Cleanup is the whole safety story here, since the fixtures live in the real
+// tree rather than a temp dir.
+test('leaves no fixture behind', () => {
+  for (const p of [
+    'public/__plan-not-book-fixture.txt',
+    'public/__plan-not-book-fixture.md',
+    'src/__plan-not-book-fixture.ts',
+  ]) {
+    if (existsSync(resolve(ROOT, p))) {
+      throw new Error(`fixture survived the run: ${p}`);
+    }
+  }
+});
+
+console.log(`\n${passed} passed, ${failed} failed`);
+if (failed > 0) process.exit(1);

--- a/scripts/check-plan-not-book.mjs
+++ b/scripts/check-plan-not-book.mjs
@@ -20,8 +20,15 @@ import { readFileSync, readdirSync, lstatSync, existsSync } from 'node:fs';
 import { join, relative } from 'node:path';
 
 const ROOT = process.cwd();
-const SCAN_DIRS = ['src'];
-const EXTS = new Set(['.ts', '.tsx', '.js', '.jsx', '.html', '.css', '.md']);
+// `public` is scanned as well as `src`: files there are served verbatim to
+// crawlers, agents and anyone who asks for them, so they are copy in every
+// sense that matters legally. public/llms.txt described "aggregate pricing
+// across booking platforms" for months precisely because this guard could not
+// see it (JAR-20).
+const SCAN_DIRS = ['src', 'public'];
+// .txt included for the same reason: llms.txt and robots.txt are published
+// copy, not configuration.
+const EXTS = new Set(['.ts', '.tsx', '.js', '.jsx', '.html', '.css', '.md', '.txt']);
 const SKIP_DIRS = new Set(['node_modules', 'dist', 'build', '.git', '.cache', '.next', 'coverage']);
 const MAX_FILE_BYTES = 2 * 1024 * 1024; // generated/binary blobs are not copy
 


### PR DESCRIPTION
Closes JAR-20.

## The file already existed. It was wrong, and CI couldn't see it.

`public/llms.txt` has been shipping for a while. What it told agents:

| Claim | Reality |
|---|---|
| "Hotel Price Comparison: Aggregate pricing across **booking platforms** with price-drop alerts" | Not a feature. And it's the exact banned lexicon — under CA B&P 17550.1, *advertising* the ability to arrange travel is itself the trigger |
| Home page has "testimonials" | There are none. Voice rules hold testimonials back until real arm's-length users exist |
| `/signin` and `/signup` pages | The router has 8 routes; neither is one. Two of ten links 404 |
| `www.jarvistravel.com` throughout | Canonical is the bare domain (`index.html`, `sitemap.xml`) |
| "Features" page | It's "How it works" in both nav and footer |
| Fatigue Index "**scores**" itineraries | The one verb the voice rules single out. Days *read* chill, balanced or packed |

It also published a **Technical information** section naming the BFF API host, the deployment targets, and the internal repo list (`core`, `web-app`, `ops-dashboard`, `monitoring`, `waitlist`). Infrastructure disclosure to anyone who fetches the file, with zero benefit to a traveler asking an assistant about the product. **Deleted rather than corrected.**

## Why it drifted, and the actual fix

```js
const SCAN_DIRS = ['src'];                                  // public/ invisible
const EXTS = new Set([..., '.html', '.css', '.md']);        // no .txt
```

Files under `public/` are served **verbatim** to crawlers, agents and anyone who asks. They are copy in every sense that matters legally, and none were checked.

**Proof this is the real story:** revert the guard, run it against the *old* llms.txt →

```
plan-not-book check passed — no banned travel-booking language found.
```

The banned language sat in the repo with CI green on every commit.

Widened to `['src', 'public']` + `.txt`. It then **immediately flagged a line in my own rewrite** ("It does not book anything"). I rewrote the copy rather than adding an allowlist entry — the allowlist is for standing legal exceptions, not convenience.

## The rewrite

- Page descriptions derive from `src/app/seo/routeMeta.ts`, the site's own source of truth, so the two can't drift.
- Feature copy comes from the shipped Home and How-it-works pages.
- **Prices deliberately not restated.** Pricing is being single-sourced from Stripe in #36; a static second copy is the problem that PR is solving. llms.txt points at `/pricing` instead.
- New **"What JarvisTravel does not do"** section — the part with real value for an agent. It plans; it never reserves or pays for anything, takes no commissions, carries no ads, doesn't sell your journal. An assistant reading this file cannot offer to arrange a trip on the strength of it.
- Fatigue Index section states it rates the *itinerary, not the person* (no wearables, no biometrics, no self-reported health), which is the answer agents should give.

Voice checked against the jarvistravel-copy rules: no em dashes, no booking lexicon, no "coming soon"/"early access"/waitlist framing, words-lead-digits-explain on the Fatigue Index, JarvisTravel one word.

## Tests

`scripts/__tests__/check-plan-not-book.test.mjs`, matching the existing no-framework convention beside the logo-generator test. They assert the guard's **reach**, not its regexes:

- banned language in `public/*.txt` is caught (the actual blind spot)
- ...in `public/*.md`
- ...in `src/*.ts` (the original coverage must not regress)
- the committed tree is clean
- no fixture survives the run

**Mutation-checked**: reverting `SCAN_DIRS`/`EXTS` fails the two `public/` cases while `src/` keeps passing — precisely the old blind spot. Wired into `test:scripts`, which `pr-checks.yml` already runs.

## Verification

```
npm run lint:plan-not-book   passed
npm run test:scripts         15 passed, 0 failed
npm run lint                 clean
npm run type-check           clean
npm run build                clean
```

## Note

The waitlist site has no llms.txt. It's the only live surface today, but it's replaced by this site at GA, so I'd rather not maintain two. Say the word if you want one there in the meantime.
