### PR TITLE
docs(privacy): say what this site does with cookies [JAR-770]

### DIFF
--- a/src/app/pages/PrivacyPage.tsx
+++ b/src/app/pages/PrivacyPage.tsx
@@ -54,6 +54,27 @@ const SECTIONS: Section[] = [
       </>
     ),
   },
+  {
+    // Scoped to THIS WEBSITE on purpose, and verified rather than asserted:
+    // no document.cookie, no localStorage, no analytics tag and no external
+    // script, font or CDN reference anywhere in the source, and the deployed
+    // site returns zero Set-Cookie headers (JAR-770). The only outbound
+    // references are the two social links in the footer, which are links, not
+    // embeds.
+    //
+    // It deliberately says nothing about the app at app.jarvistravel.com. That
+    // is a different surface with a different answer, and its policy is
+    // JAR-69. Claiming anything here about a surface this page does not cover
+    // is the shape of overclaim this ticket exists to remove.
+    title: '5. Cookies',
+    body: (
+      <>
+        This website doesn&rsquo;t set cookies. No analytics, no advertising
+        tags, and nothing loading from another company in the background. If
+        that changes, this page changes first.
+      </>
+    ),
+  },
 ];
 
 export function PrivacyPage() {
@@ -68,7 +89,7 @@ export function PrivacyPage() {
           <h1 className="text-4xl md:text-5xl font-bold text-gray-50 leading-tight [text-wrap:balance]">
             Privacy Policy
           </h1>
-          <p className="text-sky-200 text-sm mt-4">Last updated: July 2026</p>
+          <p className="text-sky-200 text-sm mt-4">Last updated: August 2026</p>
         </div>
       </section>
 


### PR DESCRIPTION
The footer links to `/privacy` for cookies and the page had nothing to say about them. This adds a section, and it is short because the true answer is short.

## Verified, not asserted

That is the point of the ticket this comes from, so the claim was checked before it was written:

| check | result |
|---|---|
| `document.cookie` / `localStorage` / `sessionStorage` in `src/` | none |
| analytics tags (gtag, GTM, Plausible, PostHog, Mixpanel, Segment, Fathom) | none |
| external script, font or CDN reference in `src/` or `index.html` | none |
| `Set-Cookie` headers from the deployed site | **0** |
| script/link tags on the live page | all root-relative |

The only outbound references anywhere are the two social links in the footer, and they are links rather than embeds.

## Two deliberate limits

**Scoped to this website.** The app at `app.jarvistravel.com` is a different surface with a different answer, and its policy is JAR-69. Claiming anything here about a surface this page does not cover would be exactly the shape of overclaim JAR-770 exists to remove. The comment in the file says so, so the next person does not "helpfully" broaden it.

**"If that changes, this page changes first"** rather than a promise to ask for consent. The consent mechanism is JAR-279 and is not built. A policy should not describe a control that does not exist.

## Last updated

Moves to August 2026. A policy whose text changes while its date does not is worse than carrying no date at all. `TermsPage` is untouched, so its July date stays.

## Verification

- `npm run lint`: clean at `--max-warnings 0`
- `check-plan-not-book`: passes
- `npm run build`: succeeds
- Rendered in a browser and read back off the page

Worth noting how that last one went. My first render check ran against a dev server that was serving the **main checkout** rather than this worktree, so the page showed four sections and the change looked broken. It was the check that was broken. Re-run against the right tree, section 5 is there.

## Overlap

marketing-website#41 (JAR-896) also touches `PrivacyPage.tsx`, but only a single line inside section 2's body (`never sell` → `don't sell`). This adds a new entry to the same array, so the two merge cleanly in either order.