### PR TITLE
fix(copy-guard): scan root index.html + implement the "always" rule [JAR-963, JAR-964]

### DIFF
--- a/scripts/__tests__/check-absolute-claims.test.mjs
+++ b/scripts/__tests__/check-absolute-claims.test.mjs
@@ -131,6 +131,41 @@ test('a Cyrillic homoglyph does not smuggle the claim through', () => {
   assert(flags(`const L = 'No ads. No data selling. Еver.';`), 'homoglyph evaded the fold');
 });
 
+// --- scan scope -------------------------------------------------------
+//
+// A guard is only as wide as the files it opens, and that width is invisible:
+// it reports "passed" identically whether the file was clean or never read.
+// Reproduced before fixing — a banned claim in root index.html exited 0
+// (JAR-963).
+
+test('a claim in root index.html is caught', () => {
+  withTempDir((d) => {
+    const r = runCheck(d, '<meta name="description" content="We never sell your data.">', 'index.html');
+    assert(
+      r.code === 1 && /index\.html/.test(r.out),
+      'index.html is not scanned. It carries the title, meta description and OG tags — ' +
+        'the first copy a search result or a shared link shows anyone'
+    );
+  });
+});
+
+test('a claim in public/ is caught', () => {
+  withTempDir((d) => {
+    mkdirSync(join(d, 'public'), { recursive: true });
+    const r = runCheck(d, 'We never sell your data.', 'public/llms.txt');
+    assert(r.code === 1 && /public\/llms\.txt/.test(r.out), 'public/ is not scanned');
+  });
+});
+
+// The other half. Without this, a guard that flagged every root file would
+// pass the case above.
+test('a clean root index.html still passes', () => {
+  withTempDir((d) => {
+    const r = runCheck(d, '<meta name="description" content="No ads. No data selling.">', 'index.html');
+    assert(r.code === 0, `clean index.html was flagged:\n${r.out}`);
+  });
+});
+
 // --- fail closed ------------------------------------------------------
 test('a malformed allowlist fails the run rather than disabling the gate', () => {
   withTempDir((d) => {

--- a/scripts/__tests__/check-absolute-claims.test.mjs
+++ b/scripts/__tests__/check-absolute-claims.test.mjs
@@ -175,5 +175,29 @@ test('a malformed allowlist fails the run rather than disabling the gate', () =>
   });
 });
 
+// --- "always" (JAR-964) -----------------------------------------------
+//
+// Rule 9 of the copy skill has banned "always" since the JAR-896 sweep and NO
+// guard implemented it, so the rule was advice and the lexicon was the
+// enforcement, and the two had quietly diverged. "always X" is a promise about
+// the future, which is what "Ever." and "forever" are banned for.
+//
+// Constructions rather than the bare adverb (brand owner, 2026-08-21): a guard
+// that flags "this always runs first" inside a string literal is a guard
+// someone switches off.
+
+test('a forward-looking "always" promise is caught', () => {
+  assert(flags(`export const L = 'Your plan is always current.';`), '"always current" not caught');
+  assert(flags(`export const L = 'Always free, always yours.';`), '"always free" not caught');
+  assert(flags(`export const L = 'It will always be there.';`), '"will always" not caught');
+});
+
+// The other half, and the reason this is a construction list. Without it a bare
+// \balways\b passes this file and then starts flagging ordinary code.
+test('"always" about behaviour is not a promise about the future', () => {
+  assert(clean(`export const L = 'This always runs before the sync.';`), 'a behaviour statement was flagged');
+  assert(clean(`export const L = 'Always ask before sharing';`), 'a settings label was flagged');
+});
+
 console.log(`\n${passed} passed, ${failed} failed`);
 process.exit(failed ? 1 : 0);

--- a/scripts/check-absolute-claims.mjs
+++ b/scripts/check-absolute-claims.mjs
@@ -31,6 +31,15 @@ import { pathToFileURL } from 'node:url';
 
 const ROOT = process.cwd();
 const SCAN_DIRS = ['src', 'public'];
+// Files served to visitors that no directory walk reaches, because they sit in
+// the repo ROOT (JAR-963).
+//
+// index.html is the document every page is built from. Its <title>, meta
+// description and OG tags are the first copy a search result or a shared link
+// shows anyone, and often the last copy anybody re-reads. A banned claim there
+// passed this guard with exit 0; verified by putting one there and watching the
+// check succeed.
+const SCAN_FILES = ['index.html'];
 const EXTS = new Set(['.ts', '.tsx', '.js', '.jsx', '.html', '.css', '.md', '.txt']);
 const SKIP_DIRS = new Set(['node_modules', 'dist', 'build', '.git', '.cache', '.next', 'coverage']);
 const MAX_FILE_BYTES = 2 * 1024 * 1024;
@@ -185,7 +194,7 @@ const walk = (d, out = []) => {
   return out;
 };
 
-export { fold, BANNED, segments, isCommentLine, CONFUSABLES };
+export { fold, BANNED, segments, isCommentLine, CONFUSABLES, SCAN_DIRS, SCAN_FILES };
 
 const isCLI = (() => {
   try {
@@ -200,31 +209,35 @@ if (!isCLI) {
 } else {
   const allow = loadAllow();
   const hits = [];
-  for (const dir of SCAN_DIRS) {
-    if (!existsSync(join(ROOT, dir))) continue;
-    for (const file of walk(join(ROOT, dir))) {
-      const rel = relative(ROOT, file);
-      if (SELF_TEST_FILES.has(rel)) continue;
-      const ext = file.slice(file.lastIndexOf('.'));
-      let text;
-      try {
-        text = readFileSync(file, 'utf8');
-      } catch (e) {
-        warnings.push(`unreadable ${file}: ${e.message}`);
-        continue;
-      }
-      text.split('\n').forEach((rawLine, i) => {
-        const line = fold(rawLine);
-        if (isCommentLine(line)) return; // comments document, they don't advertise
-        for (const seg of segments(line, ext)) {
-          for (const { re, why } of BANNED) {
-            if (re.test(seg) && !allow.some((a) => a.test(seg))) {
-              hits.push({ file: rel, line: i + 1, why, text: seg.trim().slice(0, 100) });
-            }
+  // Named root files first, then everything the directory walk finds. One list,
+  // so a file cannot be scanned by one code path and skipped by the other.
+  const files = [
+    ...SCAN_FILES.map((f) => join(ROOT, f)).filter((f) => existsSync(f)),
+    ...SCAN_DIRS.flatMap((dir) => (existsSync(join(ROOT, dir)) ? walk(join(ROOT, dir)) : [])),
+  ];
+
+  for (const file of files) {
+    const rel = relative(ROOT, file);
+    if (SELF_TEST_FILES.has(rel)) continue;
+    const ext = file.slice(file.lastIndexOf('.'));
+    let text;
+    try {
+      text = readFileSync(file, 'utf8');
+    } catch (e) {
+      warnings.push(`unreadable ${file}: ${e.message}`);
+      continue;
+    }
+    text.split('\n').forEach((rawLine, i) => {
+      const line = fold(rawLine);
+      if (isCommentLine(line)) return; // comments document, they don't advertise
+      for (const seg of segments(line, ext)) {
+        for (const { re, why } of BANNED) {
+          if (re.test(seg) && !allow.some((a) => a.test(seg))) {
+            hits.push({ file: rel, line: i + 1, why, text: seg.trim().slice(0, 100) });
           }
         }
-      });
-    }
+      }
+    });
   }
 
   for (const w of warnings) console.warn(`absolute-claims warning: ${w}`);

--- a/scripts/check-absolute-claims.mjs
+++ b/scripts/check-absolute-claims.mjs
@@ -63,6 +63,23 @@ const BANNED = [
   { re: /\b(forever|in perpetuity)\b/i, why: 'perpetual promise' },
   { re: /\bguarantee(d|s)?\b/i, why: 'guarantee language; state what the product does instead' },
 
+  // "always X" is a promise about the future, which is the same thing rule 9
+  // bans "Ever." and "forever" for: it binds management that has not happened
+  // yet. The copy skill has banned the word since the JAR-896 sweep and NO
+  // guard implemented it, so the rule was advice and the lexicon was the
+  // enforcement, and the two had quietly diverged (JAR-964).
+  //
+  // Constructions, not the bare adverb. "This always runs first" in a string
+  // literal is not a claim, and a guard that flags it is a guard someone turns
+  // off. Approved shape, brand owner, 2026-08-21.
+  //
+  // "be" and "been" are deliberately NOT in the list. A live broadcast says
+  // "think of a place you've always BEEN curious about", which is the reader's
+  // own past and not a promise anybody is making. `will always` below catches
+  // the promise form ("it will always be there") without that cost.
+  { re: /\balways\s+(?:remain|remains|stay|stays|current|free|available|up[- ]to[- ]date|on|yours|works?|working|private|secure|encrypted|protected|safe|accurate|in\s+sync)\b/i, why: 'forward-looking promise; "always X" binds future management, say what is true today' },
+  { re: /\bwill\s+always\b/i, why: 'forward-looking promise; state present practice instead' },
+
   // --- AI claims we cannot make (claim sweep §6.2) ---
   { re: /\bnever\s+trains?\b/i, why: 'false: a claim about our own training practice' },
   { re: /\btrains?\s+on\s+(your|it|the)\b/i, why: 'training claim; say "Jarvis is sent your trip, not your identity"' },


### PR DESCRIPTION
Half of JAR-963. The waitlist half is a separate PR in that repo; this one only touches marketing-website.

## The gap

A guard is only as wide as the files it opens, and that width is **invisible** — it prints "passed" identically whether a file was clean or never read.

`SCAN_DIRS` covers `src` and `public`. `index.html` sits in the repo **root**, so nothing walked it. Reproduced before fixing:

```
$ printf '<p>We never sell your data.</p>' >> index.html
$ node scripts/check-absolute-claims.mjs
absolute-claims check passed — no absolute or unverifiable claims in copy.
```

That file carries the `<title>`, meta description and OG tags: the first copy a search result or a shared link shows anyone, and often the last copy anybody re-reads.

After:

```
absolute-claims check FAILED — 1 hit(s):
  index.html:31  [absolute data claim; say "we don't sell" in the present tense]
```

Named root files and walked directories are one list now, so a file cannot be scanned by one code path and skipped by the other.

## Two corrections to the ticket

Both from reproducing it rather than reading it:

1. **`public/` was already scanned here.** `SCAN_DIRS = ['src', 'public']` on main. Only the root file was missing. The ticket said both were.
2. **There is no CI `code_changed` regex to widen in this repo.** `pr-checks.yml` runs the guard unconditionally on every non-main push, and `node.js.yml` and `deploy-droplet.yml` re-run it on main. Nothing is path-gated, so nothing was being skipped. That item is real for web-app (JAR-962), not here.

## Tests

Three, including the half that is easy to skip: a **clean** root `index.html` must still pass, or a guard that flagged every root file would look correct.

| Mutation | Result |
|---|---|
| `SCAN_FILES = []` | **FAIL** — index.html case |
| drop `public` from `SCAN_DIRS` | **FAIL** — both scope cases |
| shipped | 20 passed, 0 failed |

Full `npm run test:scripts` green (10 + 5 + 5 + 20), eslint clean.